### PR TITLE
feat(functions): add show_spend_time parameter in openwebui_monitor.py

### DIFF
--- a/resources/functions/openwebui_monitor.py
+++ b/resources/functions/openwebui_monitor.py
@@ -18,6 +18,7 @@ class Filter:
         show_balance: bool = Field(
             default=True, description="Display balance information"
         )
+        show_spend_time: bool = Field(default=True, description="Display spend time")
         show_tokens: bool = Field(default=True, description="Display token usage")
         show_tokens_per_sec: bool = Field(
             default=True, description="Display tokens per second"
@@ -145,7 +146,7 @@ class Filter:
                 stats_array.append(f"Token: {input_tokens}+{output_tokens}")
 
             # 计算耗时（如果有start_time）
-            if self.start_time:
+            if self.start_time and self.valves.show_spend_time:
                 elapsed_time = time.time() - self.start_time
                 stats_array.append(f"耗时: {elapsed_time:.2f}s")
                 


### PR DESCRIPTION
- 在 openwebui_monitor.py 文件中新增 show_spend_time 参数
- 支持控制是否显示耗时信息
之前的函数无法通过设置关闭耗时的显示：
![QQ_1733744422792](https://github.com/user-attachments/assets/f45b538a-c51d-4b31-b231-aa82fc301b28)
修改后支持后台配置是否显示耗时
![QQ_1733744480859](https://github.com/user-attachments/assets/caa4c334-79a1-47c0-94dc-72db5a8d3b33)
