### PR TITLE
修复了系统提示和文件token无法被计算的问题

### DIFF
--- a/resources/functions/openwebui_monitor.py
+++ b/resources/functions/openwebui_monitor.py
@@ -61,6 +61,7 @@ class Filter:
         self.outage = False
         self.start_time = None
         self.translations = TRANSLATIONS
+        self.inlet_temp = None
 
     def get_text(self, key: str, **kwargs) -> str:
         """获取指定语言的文本"""
@@ -86,7 +87,13 @@ class Filter:
             body_dict["metadata"]["model"] = body_dict["metadata"]["model"].model_dump()
 
         return body_dict
-
+    def _modify_outlet_body(self, body: dict) -> dict:
+        body_modify = dict(body)
+        if body_modify["messages"][-1].get("info") is None:
+            if not self.inlet_temp is None:
+                body_modify["messages"][:-1] = self.inlet_temp["messages"]
+        return body_modify
+        
     def inlet(
         self, body: dict, user: Optional[dict] = None, __user__: dict = {}
     ) -> dict:
@@ -98,6 +105,7 @@ class Filter:
             
             user_dict = self._prepare_user_dict(__user__)
             body_dict = self._prepare_body_dict(body)
+            self.inlet_temp = body_dict
             response = requests.post(
                 post_url, headers=headers, json={"user": user_dict, "body": body_dict}
             )
@@ -116,7 +124,6 @@ class Filter:
             self.outage = response_data.get("balance", 0) <= 0
             if self.outage:
                 raise Exception(self.get_text("insufficient_balance", balance=response_data['balance']))
-
             return body
 
         except requests.exceptions.RequestException as e:
@@ -144,10 +151,11 @@ class Filter:
             headers = {"Authorization": f"Bearer {self.valves.API_KEY}"}
             
             user_dict = self._prepare_user_dict(__user__)
+            body_modify = self._modify_outlet_body(body)
             
             request_data = {
                 "user": user_dict,
-                "body": body,
+                "body": body_modify,
             }
 
             response = requests.post(post_url, headers=headers, json=request_data)

--- a/resources/functions/openwebui_monitor.py
+++ b/resources/functions/openwebui_monitor.py
@@ -89,9 +89,10 @@ class Filter:
         return body_dict
     def _modify_outlet_body(self, body: dict) -> dict:
         body_modify = dict(body)
-        if body_modify["messages"][-1].get("info") is None:
-            if not self.inlet_temp is None:
-                body_modify["messages"][:-1] = self.inlet_temp["messages"]
+        last_message = body_modify["messages"][-1]
+    
+        if "info" not in last_message and self.inlet_temp is not None:
+            body_modify["messages"][:-1] = self.inlet_temp["messages"]
         return body_modify
         
     def inlet(


### PR DESCRIPTION
将inlet中的messages 与 outlet中的 messages  最后一个元素拼接作为新的 outlet messages 传递给 后端进行token计算，保证能正确计算到系统提示以及文件

修正前
![image](https://github.com/user-attachments/assets/5616c394-23c2-4a5c-b195-59e3e56db894)
修正后
![image](https://github.com/user-attachments/assets/b49e9ff8-ede9-4658-9f28-d94939060f2e)
