### PR TITLE
Add Reasoning Tokens to Output Tokens Calculations

### DIFF
--- a/app/api/v1/outlet/route.ts
+++ b/app/api/v1/outlet/route.ts
@@ -93,7 +93,12 @@ export async function POST(req: Request) {
       lastMessage.usage.completion_tokens
     ) {
       inputTokens = lastMessage.usage.prompt_tokens;
-      outputTokens = lastMessage.usage.completion_tokens;
+      if (lastMessage.usage.completion_tokens_details.reasoning_tokens) {
+        outputTokens = lastMessage.usage.completion_tokens +
+                       lastMessage.usage.completion_tokens_details.reasoning_tokens;
+      } else {
+        outputTokens = lastMessage.usage.completion_tokens;
+      }
     } else {
       outputTokens = encode(lastMessage.content).length;
       const totalTokens = data.body.messages.reduce(


### PR DESCRIPTION
原先outputTokens的计算中没有考虑到reasoning tokens，导致reasoning models的显示价格与实际花费不一致。
