### PR TITLE
Change tokens calculation algorithm to coordinate with Grok's usage parameters

### DIFF
--- a/app/api/v1/outlet/route.ts
+++ b/app/api/v1/outlet/route.ts
@@ -85,15 +85,17 @@ export async function POST(req: Request) {
 
     const lastMessage = data.body.messages[data.body.messages.length - 1];
 
+    let totalTokens: number;
     let inputTokens: number;
     let outputTokens: number;
     if (
       lastMessage.usage &&
       lastMessage.usage.prompt_tokens &&
-      lastMessage.usage.completion_tokens
+      lastMessage.usage.total_tokens
     ) {
+      totalTokens = lastMessage.usage.total_tokens;
       inputTokens = lastMessage.usage.prompt_tokens;
-      outputTokens = lastMessage.usage.completion_tokens;
+      outputTokens = totalTokens - inputTokens;
     } else {
       outputTokens = encode(lastMessage.content).length;
       const totalTokens = data.body.messages.reduce(

--- a/app/api/v1/outlet/route.ts
+++ b/app/api/v1/outlet/route.ts
@@ -93,12 +93,7 @@ export async function POST(req: Request) {
       lastMessage.usage.completion_tokens
     ) {
       inputTokens = lastMessage.usage.prompt_tokens;
-      if (lastMessage.usage.completion_tokens_details.reasoning_tokens) {
-        outputTokens = lastMessage.usage.completion_tokens +
-                       lastMessage.usage.completion_tokens_details.reasoning_tokens;
-      } else {
-        outputTokens = lastMessage.usage.completion_tokens;
-      }
+      outputTokens = lastMessage.usage.completion_tokens;
     } else {
       outputTokens = encode(lastMessage.content).length;
       const totalTokens = data.body.messages.reduce(

--- a/app/api/v1/outlet/route.ts
+++ b/app/api/v1/outlet/route.ts
@@ -93,7 +93,12 @@ export async function POST(req: Request) {
       lastMessage.usage.completion_tokens
     ) {
       inputTokens = lastMessage.usage.prompt_tokens;
-      outputTokens = lastMessage.usage.completion_tokens;
+      if (lastMessage.usage.completion_tokens_details.reasoning_tokens) {
+        outputTokens = lastMessage.usage.completion_tokens +
+                       lastMessage.usage.completion_tokens_details.reasoning_tokens;
+      } else {
+        outputTokens = lastMessage.usage.completion_tokens;
+      }
     } else {
       outputTokens = encode(lastMessage.content).length;
       const totalTokens = data.body.messages.reduce(


### PR DESCRIPTION
Grok API seperates completion_tokens with reasoning_tokens in the usage block, while OpenAI API takes reasoning_tokens in the calculation of completion_tokens. To adapt both APIs, the outputTokens is changed to total tokens subtracted by input tokens.