### PR TITLE
fix: add Authorization header to Records page API calls

### DIFF
--- a/app/records/page.tsx
+++ b/app/records/page.tsx
@@ -174,8 +174,14 @@ export default function RecordsPage() {
                 }
             }
 
+            const token = localStorage.getItem('access_token')
             const response = await fetch(
-                `/api/v1/panel/records?${searchParams.toString()}`
+                `/api/v1/panel/records?${searchParams.toString()}`,
+                {
+                    headers: {
+                        Authorization: `Bearer ${token}`,
+                    },
+                }
             )
             const data = await response.json()
 
@@ -225,7 +231,12 @@ export default function RecordsPage() {
 
     const handleExport = async () => {
         try {
-            const response = await fetch('/api/v1/panel/records/export')
+            const token = localStorage.getItem('access_token')
+            const response = await fetch('/api/v1/panel/records/export', {
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                },
+            })
             const blob = await response.blob()
             const url = window.URL.createObjectURL(blob)
             const a = document.createElement('a')

--- a/app/records/page.tsx
+++ b/app/records/page.tsx
@@ -58,7 +58,7 @@ export default function RecordsPage() {
             title: t('records.columns.user'),
             dataIndex: 'nickname',
             key: 'nickname',
-            filters: users.map((user) => ({ text: user, value: user })),
+            filters: (users || []).map((user) => ({ text: user, value: user })),
             filterMode: 'tree',
             filterSearch: true,
             width: 200,
@@ -80,7 +80,7 @@ export default function RecordsPage() {
             title: t('records.columns.model'),
             dataIndex: 'model_name',
             key: 'model_name',
-            filters: models.map((model) => ({ text: model, value: model })),
+            filters: (models || []).map((model) => ({ text: model, value: model })),
             filterMode: 'tree',
             filterSearch: true,
             width: 200,
@@ -175,6 +175,10 @@ export default function RecordsPage() {
             }
 
             const token = localStorage.getItem('access_token')
+            if (!token) {
+                toast.error(t('auth.accessTokenRequired'))
+                return
+            }
             const response = await fetch(
                 `/api/v1/panel/records?${searchParams.toString()}`,
                 {
@@ -183,19 +187,31 @@ export default function RecordsPage() {
                     },
                 }
             )
+            
+            if (!response.ok) {
+                if (response.status === 401) {
+                    toast.error(t('auth.invalidToken'))
+                    localStorage.removeItem('access_token')
+                    window.location.href = '/token'
+                } else {
+                    toast.error(t('error.panel.fetchUsageDataFail'))
+                }
+                return
+            }
+            
             const data = await response.json()
 
-            setRecords(data.records)
+            setRecords(data.records || [])
             setTableParams({
                 ...params,
                 pagination: {
                     ...params.pagination,
-                    total: data.total,
+                    total: data.total || 0,
                 },
             })
 
-            setUsers(data.users as string[])
-            setModels(data.models as string[])
+            setUsers((data.users as string[]) || [])
+            setModels((data.models as string[]) || [])
         } catch (error) {
             toast.error(t('error.panel.fetchUsageDataFail'))
         } finally {
@@ -232,11 +248,28 @@ export default function RecordsPage() {
     const handleExport = async () => {
         try {
             const token = localStorage.getItem('access_token')
+            if (!token) {
+                toast.error(t('auth.accessTokenRequired'))
+                window.location.href = '/token'
+                return
+            }
             const response = await fetch('/api/v1/panel/records/export', {
                 headers: {
                     Authorization: `Bearer ${token}`,
                 },
             })
+            
+            if (!response.ok) {
+                if (response.status === 401) {
+                    toast.error(t('auth.invalidToken'))
+                    localStorage.removeItem('access_token')
+                    window.location.href = '/token'
+                } else {
+                    toast.error(t('error.model.failToExport'))
+                }
+                return
+            }
+            
             const blob = await response.blob()
             const url = window.URL.createObjectURL(blob)
             const a = document.createElement('a')

--- a/generate_keys.py
+++ b/generate_keys.py
@@ -1,0 +1,16 @@
+import secrets
+import string
+
+def generate_random_string(length=32):
+    characters = string.ascii_letters + string.digits
+    return ''.join(secrets.choice(characters) for _ in range(length))
+
+def main():
+    access_token = generate_random_string()
+    api_key = generate_random_string()
+
+    print(f"ACCESS_TOKEN={access_token}")
+    print(f"API_KEY={api_key}")
+
+if __name__ == "__main__":
+    main()

--- a/usage_records.csv
+++ b/usage_records.csv
@@ -1,0 +1,1164 @@
+User,Time,Model,Input tokens,Output tokens,Cost,Balance
+open-ui,6/23/2026, 10:00:16 AM,google/gemma-4-26B-A4B-it,8430,568,0.0019,90547.1180
+Seema Mathew,6/23/2026, 9:38:18 AM,ministral-3:latest,548,469,0.0001,905.5034
+open-ui,6/23/2026, 9:30:31 AM,google/gemma-4-26B-A4B-it,8022,387,0.8409,90547.1199
+Seema Mathew,6/23/2026, 9:09:50 AM,ministral-3:14b,17642,1099,1.8741,905.5035
+open-ui,6/22/2026, 11:37:20 AM,google/gemma-4-26B-A4B-it,246,669,0.0915,90547.9608
+open-ui,6/22/2026, 11:37:09 AM,google/gemma-4-26B-A4B-it,1,234,0.0235,90548.0523
+open-ui,6/21/2026, 8:28:15 AM,gemma4:12b,6729,1082,0.7811,90548.0758
+open-ui,6/21/2026, 8:27:09 AM,gemma4:12b,6467,1309,0.7776,90548.8569
+open-ui,6/21/2026, 8:25:25 AM,google/gemma-4-26B-A4B-it,4762,282,0.5044,90549.6345
+open-ui,6/21/2026, 8:24:25 AM,google/gemma-4-26B-A4B-it,4376,366,0.4742,90550.1389
+open-ui,6/20/2026, 9:32:28 PM,google/gemma-4-26B-A4B-it,3479,880,0.4359,90550.6131
+open-ui,6/20/2026, 5:31:05 PM,google/gemma-4-26B-A4B-it,2299,996,0.3295,90551.0490
+open-ui,6/20/2026, 5:23:06 PM,google/gemma-4-26B-A4B-it,1665,614,0.2279,90551.3785
+open-ui,6/20/2026, 5:01:53 PM,google/gemma-4-26B-A4B-it,745,899,0.1644,90551.6064
+open-ui,6/20/2026, 5:01:05 PM,google/gemma-4-26B-A4B-it,745,790,0.1535,90551.7708
+open-ui,6/20/2026, 4:53:47 PM,google/gemma-4-26B-A4B-it,55,669,0.0724,90551.9243
+Seema Mathew,6/19/2026, 12:45:21 PM,ministral-3:latest,10596,1115,1.1711,907.3776
+open-ui,6/19/2026, 7:07:56 AM,gemma4:12b,10509,1311,1.1820,90551.9967
+open-ui,6/19/2026, 7:02:32 AM,google/gemma-4-26B-A4B-it,17302,445,1.7747,90553.1787
+open-ui,6/19/2026, 6:53:32 AM,google/gemma-4-26B-A4B-it,16579,698,1.7277,90554.9534
+open-ui,6/18/2026, 10:25:03 PM,google/gemma-4-26B-A4B-it,16106,455,1.6561,90556.6811
+open-ui,6/18/2026, 10:23:46 PM,google/gemma-4-26B-A4B-it,15520,566,1.6086,90558.3372
+open-ui,6/18/2026, 10:23:10 PM,google/gemma-4-26B-A4B-it,15048,453,1.5501,90559.9458
+open-ui,6/18/2026, 10:21:48 PM,gemma4:12b,7863,6673,1.4536,90561.4959
+open-ui,6/18/2026, 9:20:38 PM,qwen3.6:latest,6768,5469,1.2237,90562.9495
+open-ui,6/18/2026, 9:11:57 PM,google/gemma-4-26B-A4B-it,17,1477,0.1494,90564.1732
+open-ui,6/18/2026, 9:09:42 PM,google/gemma-4-26B-A4B-it,6597,1034,0.7631,90564.3226
+open-ui,6/18/2026, 9:05:39 PM,google/gemma-4-26B-A4B-it,27064,1197,2.8261,90565.0857
+open-ui,6/18/2026, 9:04:40 PM,google/gemma-4-26B-A4B-it,25814,1236,2.7050,90567.9118
+open-ui,6/18/2026, 9:02:36 PM,google/gemma-4-26B-A4B-it,24526,1262,2.5788,90570.6168
+open-ui,6/18/2026, 9:01:37 PM,google/gemma-4-26B-A4B-it,23279,1228,2.4507,90573.1956
+open-ui,6/18/2026, 3:15:37 PM,viewpoint-local,3417,556,0.1192,90575.6463
+open-ui,6/18/2026, 3:14:48 PM,viewpoint-local,1768,1627,0.1019,90575.7655
+open-ui,6/17/2026, 2:37:36 PM,openai/gpt-oss-20b,4807,1760,0.6567,90575.8674
+open-ui,6/17/2026, 10:19:30 AM,openai/gpt-oss-20b,3750,1041,0.4791,90576.5241
+open-ui,6/17/2026, 7:18:14 AM,viewpoint-local,7489,916,0.2522,90577.0032
+open-ui,6/17/2026, 7:16:03 AM,viewpoint-local,7489,1205,0.2608,90577.2554
+open-ui,6/17/2026, 7:14:42 AM,viewpoint-local,5507,1966,0.2242,90577.5162
+open-ui,6/17/2026, 7:13:57 AM,viewpoint-local,4409,1079,0.1646,90577.7404
+open-ui,6/17/2026, 7:13:37 AM,viewpoint-local,3473,914,0.1316,90577.9050
+open-ui,6/17/2026, 7:12:59 AM,viewpoint-local,2278,1178,0.1037,90578.0366
+open-ui,6/17/2026, 7:07:01 AM,openai/gpt-oss-20b,6154,1047,0.7201,90578.1403
+open-ui,6/17/2026, 7:06:35 AM,openai/gpt-oss-20b,5107,1023,0.6130,90578.8604
+open-ui,6/17/2026, 7:06:04 AM,gemma4:12b,1786,888,0.2674,90579.4734
+open-ui,6/17/2026, 7:05:38 AM,gemma4:12b,1127,1088,0.2215,90579.7408
+open-ui,6/17/2026, 7:04:44 AM,gemma4:12b,627,1015,0.1642,90579.9623
+open-ui,6/16/2026, 12:30:19 PM,gemma4:12b,1627,902,0.2529,90580.1265
+open-ui,6/16/2026, 12:27:38 PM,openai/gpt-oss-20b,2952,683,0.3635,90580.3794
+open-ui,6/16/2026, 12:27:18 PM,openai/gpt-oss-20b,2952,715,0.3667,90580.7429
+open-ui,6/16/2026, 12:25:39 PM,qwen3.6:latest,1576,1797,0.3373,90581.1096
+open-ui,6/16/2026, 12:23:11 PM,openai/gpt-oss-20b,2952,4832,0.7784,90581.4469
+open-ui,6/16/2026, 12:16:14 PM,openai/gpt-oss-20b,1799,1114,0.2913,90582.2253
+open-ui,6/16/2026, 12:14:39 PM,openai/gpt-oss-20b,1162,613,0.1775,90582.5166
+open-ui,6/16/2026, 12:13:17 PM,openai/gpt-oss-20b,22,1072,0.1094,90582.6941
+open-ui,6/15/2026, 11:18:33 AM,ministral3-clinical:latest,240,860,0.1100,90582.8035
+Praveenkumar Karunakaran,6/12/2026, 12:26:56 PM,qwen3.6:latest,19,203,0.0222,898.7359
+Praveenkumar Karunakaran,6/12/2026, 12:25:43 PM,gemma4:31b,40,138,0.0178,898.7581
+Praveenkumar Karunakaran,6/12/2026, 12:24:57 PM,gemma4:31b,20,71,0.0091,898.7759
+open-ui,6/11/2026, 7:44:09 AM,qwen3.6:latest,362,983,0.1345,90582.9135
+Seema Mathew,6/11/2026, 4:44:16 AM,ministral-3:latest,9805,788,1.0593,908.5487
+open-ui,6/10/2026, 2:25:02 PM,qwen3.6:latest,224,2509,0.2733,90583.0480
+Praveenkumar Karunakaran,6/10/2026, 12:07:51 PM,Qwen3-8B-Q4_K_M.gguf,38,263,0.0301,898.7850
+open-ui,6/10/2026, 11:26:34 AM,qwen3.6:latest,42,455,0.0497,90583.3213
+Praveenkumar Karunakaran,6/10/2026, 11:26:25 AM,Qwen3-8B-Q4_K_M.gguf,14,181,0.0195,898.8151
+Praveenkumar Karunakaran,6/10/2026, 11:26:09 AM,qwen3.6:latest,19,207,0.0226,898.8346
+open-ui,6/10/2026, 10:10:05 AM,qwen3.6:latest,51,1040,0.1091,90583.3710
+Seema Mathew,6/9/2026, 12:39:42 PM,ministral-3:latest,23696,1121,2.4817,909.6080
+Seema Mathew,6/9/2026, 12:36:29 PM,ministral-3:latest,22725,964,2.3689,912.0897
+Seema Mathew,6/9/2026, 12:34:57 PM,ministral-3:latest,21880,812,2.2692,914.4586
+Seema Mathew,6/9/2026, 12:33:47 PM,ministral-3:latest,21116,737,2.1853,916.7278
+Seema Mathew,6/9/2026, 12:32:16 PM,ministral-3:latest,20605,477,2.1082,918.9131
+Seema Mathew,6/9/2026, 12:25:17 PM,ministral-3:latest,18268,2269,2.0537,921.0213
+Seema Mathew,6/9/2026, 12:19:27 PM,ministral-3:latest,16459,1773,1.8232,923.0750
+Seema Mathew,6/9/2026, 12:14:22 PM,ministral-3:latest,14476,1944,1.6420,924.8982
+Seema Mathew,6/9/2026, 12:12:34 PM,ministral-3:latest,13029,1407,1.4436,926.5402
+Seema Mathew,6/9/2026, 12:10:51 PM,ministral-3:latest,11761,625,1.2386,927.9838
+Seema Mathew,6/9/2026, 12:06:53 PM,ministral-3:latest,10277,989,1.1266,929.2224
+Seema Mathew,6/9/2026, 11:59:04 AM,ministral-3:latest,9130,646,0.9776,930.3490
+Seema Mathew,6/9/2026, 11:56:20 AM,ministral-3:latest,9122,641,0.9763,931.3266
+Seema Mathew,6/9/2026, 11:52:52 AM,ministral-3:latest,9842,321,1.0163,932.3029
+Seema Mathew,6/9/2026, 11:52:10 AM,ministral-3:latest,9185,641,0.9826,933.3192
+Seema Mathew,6/9/2026, 9:12:26 AM,ministral-3:latest,12052,1236,1.3288,934.3018
+Seema Mathew,6/9/2026, 9:10:51 AM,ministral-3:latest,10945,1092,1.2037,935.6306
+Seema Mathew,6/9/2026, 9:05:39 AM,ministral-3:latest,10035,891,1.0926,936.8343
+Seema Mathew,6/9/2026, 9:03:42 AM,ministral-3:latest,8804,650,0.9454,937.9269
+Seema Mathew,6/9/2026, 9:03:06 AM,ministral-3:latest,2048,807,0.2855,938.8723
+Seema Mathew,6/9/2026, 9:02:00 AM,ministral-3:latest,2048,460,0.2508,939.1578
+Seema Mathew,6/9/2026, 7:43:37 AM,ministral-3:latest,9552,122,0.9674,939.4086
+Seema Mathew,6/9/2026, 7:42:55 AM,ministral-3:latest,8751,782,0.9533,940.3760
+Seema Mathew,6/9/2026, 7:03:00 AM,ministral-3:latest,21115,1078,2.2193,941.3293
+Seema Mathew,6/9/2026, 6:56:16 AM,ministral-3:latest,8751,782,0.9533,943.5486
+Seema Mathew,6/9/2026, 6:49:48 AM,ministral-3:latest,20241,766,2.1007,944.5019
+Seema Mathew,6/9/2026, 6:45:08 AM,ministral-3:latest,10590,710,1.1300,946.6026
+Seema Mathew,6/9/2026, 6:44:10 AM,ministral-3:latest,9842,735,1.0577,947.7326
+Seema Mathew,6/9/2026, 6:42:10 AM,ministral-3:latest,9289,529,0.9818,948.7903
+Seema Mathew,6/9/2026, 6:39:10 AM,ministral-3:latest,8525,744,0.9269,949.7721
+Seema Mathew,6/9/2026, 5:51:57 AM,ministral-3:latest,8585,116,0.8701,950.6990
+open-ui,6/8/2026, 3:27:35 PM,Qwen3-8B-Q4_K_M.gguf,23,424,0.0447,90583.4801
+Seema Mathew,6/8/2026, 8:46:49 AM,ministral-3:latest,7632,904,0.8536,951.5691
+Seema Mathew,6/8/2026, 5:32:25 AM,ministral-3:latest,5932,864,0.6796,952.4227
+Vishnu Prasad,6/6/2026, 9:58:46 AM,gemma4:31b,254,1421,0.1675,994.7983
+Vishnu Prasad,6/6/2026, 9:57:24 AM,gemma4:31b,22,626,0.0648,994.9658
+Vishnu Prasad,6/6/2026, 9:56:18 AM,qwen3.6:latest,37,610,0.0647,995.0306
+Vishnu Prasad,6/6/2026, 9:55:52 AM,qwen3.6:latest,11,284,0.0295,995.0953
+Praveenkumar Karunakaran,6/5/2026, 2:15:14 PM,gemma4:31b,1155,1718,0.2873,898.8572
+Praveenkumar Karunakaran,6/5/2026, 2:13:29 PM,gemma4:31b,27,1690,0.1717,899.1445
+Praveenkumar Karunakaran,6/5/2026, 1:59:55 PM,qwen3.6:latest,19,209,0.0228,899.3162
+Seema Mathew,6/5/2026, 10:36:47 AM,ministral-3:latest,1929,758,0.2687,953.1023
+Seema Mathew,6/5/2026, 10:35:51 AM,ministral-3:latest,1507,399,0.1906,953.3710
+Seema Mathew,6/5/2026, 10:26:53 AM,ministral-3:latest,905,536,0.1441,953.5616
+Seema Mathew,6/5/2026, 10:26:04 AM,ministral-3:latest,2120,750,0.2870,953.7057
+Seema Mathew,6/5/2026, 10:24:54 AM,ministral-3:latest,1398,715,0.2113,953.9927
+Seema Mathew,6/5/2026, 10:17:29 AM,ministral-3:latest,905,446,0.1351,954.2040
+Seema Mathew,6/5/2026, 10:03:38 AM,ministral-3:latest,1720,612,0.2332,954.3391
+Seema Mathew,6/5/2026, 9:59:15 AM,ministral-3:latest,877,451,0.1328,954.5723
+Seema Mathew,6/5/2026, 7:49:05 AM,ministral-3:latest,2640,319,0.2959,954.7051
+Seema Mathew,6/5/2026, 7:47:29 AM,ministral-3:latest,2205,335,0.2540,955.0010
+Seema Mathew,6/5/2026, 7:46:45 AM,ministral-3:latest,1846,345,0.2191,955.2550
+Seema Mathew,6/5/2026, 7:45:54 AM,ministral-3:latest,1613,211,0.1824,955.4741
+Seema Mathew,6/5/2026, 7:45:15 AM,ministral-3:latest,1505,73,0.1578,955.6565
+Seema Mathew,6/5/2026, 7:08:32 AM,ministral-3:latest,1287,51,0.1338,955.8143
+Seema Mathew,6/5/2026, 7:06:27 AM,ministral-3:latest,1042,87,0.1129,955.9481
+Seema Mathew,6/5/2026, 7:04:08 AM,ministral-3:latest,623,296,0.0919,956.0610
+Seema Mathew,6/3/2026, 1:08:40 PM,ministral-3:latest,25443,1506,2.6949,956.1529
+Seema Mathew,6/3/2026, 1:04:50 PM,llama-3.1-Nemotron-nano:latest,23852,406,2.4258,958.8478
+Seema Mathew,6/3/2026, 11:08:32 AM,ministral-3:latest,543,1269,0.1812,961.2736
+Praveenkumar Karunakaran,6/2/2026, 9:08:26 AM,gemma4:31b,28,992,0.1020,899.3390
+Praveenkumar Karunakaran,6/2/2026, 8:58:43 AM,qwen3.6:latest,1269,757,0.2026,899.4410
+Praveenkumar Karunakaran,6/2/2026, 8:57:32 AM,gemma4:31b,630,583,0.1213,899.6436
+Praveenkumar Karunakaran,6/2/2026, 8:56:21 AM,gemma4:31b,69,1077,0.1146,899.7649
+Vishnu Prasad,6/1/2026, 6:45:55 PM,gemma4:31b,10013,7855,1.7868,995.1248
+Vishnu Prasad,6/1/2026, 6:35:20 PM,Qwen3-8B-Q4_K_M.gguf,139,3547,0.3686,996.9116
+open-ui,5/27/2026, 12:15:11 PM,gemma4:31b,22042,1398,2.3440,90583.5248
+open-ui,5/27/2026, 12:12:55 PM,gemma4:31b,21359,1203,2.2562,90585.8688
+open-ui,5/27/2026, 12:03:29 PM,gemma4:31b,20837,951,2.1788,90588.1250
+open-ui,5/27/2026, 12:01:11 PM,gemma4:31b,19537,1580,2.1117,90590.3038
+Philipp Baer,5/26/2026, 4:32:12 AM,gemma4:31b,49,1318,0.1367,995.2691
+Philipp Baer,5/26/2026, 4:30:07 AM,gpt-oss-custom:latest,2981,198,0.3179,995.4058
+Philipp Baer,5/26/2026, 4:29:29 AM,ministral-3:latest,2528,317,0.2845,995.7237
+Philipp Baer,5/26/2026, 4:23:39 AM,qwen3.6:latest,2406,1262,0.3668,996.0082
+Philipp Baer,5/26/2026, 4:16:44 AM,gemma4:31b,2205,663,0.2868,996.3750
+Philipp Baer,5/26/2026, 4:14:06 AM,gemma4:31b,2093,1666,0.3759,996.6618
+Philipp Baer,5/26/2026, 4:11:18 AM,gemma4:31b,2493,699,0.3192,997.0377
+Philipp Baer,5/26/2026, 4:09:15 AM,gemma4:31b,1852,1355,0.3207,997.3569
+Philipp Baer,5/26/2026, 4:07:49 AM,gemma4:31b,1610,1070,0.2680,997.6776
+Philipp Baer,5/26/2026, 4:05:51 AM,gemma4:31b,1444,1567,0.3011,997.9456
+Philipp Baer,5/26/2026, 4:04:12 AM,gemma4:31b,1331,1710,0.3041,998.2467
+Philipp Baer,5/26/2026, 4:02:29 AM,gemma4:31b,1285,157,0.1442,998.5508
+Philipp Baer,5/26/2026, 4:01:56 AM,gemma4:31b,1188,394,0.1582,998.6950
+Philipp Baer,5/26/2026, 4:01:25 AM,gemma4:31b,946,845,0.1791,998.8532
+Philipp Baer,5/26/2026, 4:00:34 AM,gemma4:31b,869,308,0.1177,999.0323
+Philipp Baer,5/26/2026, 3:59:51 AM,gemma4:31b,804,395,0.1199,999.1500
+Philipp Baer,5/26/2026, 3:59:02 AM,gemma4:31b,776,243,0.1019,999.2699
+Philipp Baer,5/26/2026, 3:57:14 AM,gemma4:31b,397,768,0.1165,999.3718
+Philipp Baer,5/26/2026, 3:56:29 AM,gemma4:31b,208,454,0.0662,999.4883
+Philipp Baer,5/26/2026, 3:55:59 AM,gemma4:31b,22,172,0.0194,999.5545
+Philipp Baer,5/26/2026, 3:55:50 AM,gemma4:31b,71,403,0.0474,999.5739
+Seema Mathew,5/22/2026, 5:28:49 PM,ministral-3:latest,23959,142161,16.6120,961.4548
+open-ui,5/19/2026, 11:00:13 AM,Qwen3-8B-Q4_K_M.gguf,4998,2342,0.7340,90592.4155
+open-ui,5/19/2026, 10:59:04 AM,Qwen3-8B-Q4_K_M.gguf,3505,1408,0.4913,90593.1495
+open-ui,5/19/2026, 10:54:26 AM,Qwen3-8B-Q4_K_M.gguf,1630,1634,0.3264,90593.6408
+open-ui,5/19/2026, 10:53:58 AM,Qwen3-8B-Q4_K_M.gguf,56,1567,0.1623,90593.9672
+open-ui,5/19/2026, 7:56:07 AM,Qwen3-8B-Q4_K_M.gguf,746,917,0.1663,90594.1295
+open-ui,5/19/2026, 7:55:58 AM,Qwen3-8B-Q4_K_M.gguf,18,719,0.0737,90594.2958
+Praveenkumar Karunakaran,5/18/2026, 3:27:24 PM,qwen3.6:latest,49,362,0.0411,899.8795
+Praveenkumar Karunakaran,5/18/2026, 3:26:40 PM,gemma4:31b,19,136,0.0155,899.9206
+212455943,5/18/2026, 9:01:03 AM,gemma4:31b,41,794,0.0835,999.9081
+212455943,5/18/2026, 9:00:47 AM,gemma4:31b,16,68,0.0084,999.9916
+Praveenkumar Karunakaran,5/15/2026, 8:18:58 AM,gemma4:31b,26,699,0.0725,899.9361
+open-ui,5/13/2026, 1:21:44 PM,gemma4:31b,18392,1477,1.9869,90594.3695
+Praveenkumar Karunakaran,5/13/2026, 9:14:27 AM,gemma4:31b,1595,1796,0.3391,900.0086
+Praveenkumar Karunakaran,5/13/2026, 9:10:18 AM,gemma4:31b,792,1196,0.1988,900.3477
+Praveenkumar Karunakaran,5/13/2026, 8:56:56 AM,gemma4:31b,110,1251,0.1361,900.5465
+open-ui,5/12/2026, 1:45:03 PM,gemma4:31b,17828,996,1.8824,90596.3564
+open-ui,5/12/2026, 1:39:30 PM,gemma4:31b,17445,1006,1.8451,90598.2388
+open-ui,5/12/2026, 11:55:27 AM,gemma4:31b,12702,2163,1.4865,90600.0839
+open-ui,5/11/2026, 2:19:02 PM,gemma4:31b,11476,1858,1.3334,90601.5704
+open-ui,5/11/2026, 1:31:55 PM,gemma4:31b,10491,1955,1.2446,90602.9038
+Philipp Baer,5/11/2026, 10:41:54 AM,qwen3.6:latest,13,312,0.0325,999.6213
+open-ui,5/11/2026, 10:29:30 AM,gemma4:31b,9236,1860,1.1096,90604.1484
+open-ui,5/11/2026, 10:16:20 AM,gemma4:31b,14327,1780,1.6107,90605.2580
+open-ui,5/11/2026, 10:13:11 AM,gemma4:31b,13170,1342,1.4512,90606.8687
+open-ui,5/11/2026, 9:59:02 AM,gemma4:31b,12236,1376,1.3612,90608.3199
+open-ui,5/11/2026, 7:41:58 AM,gemma4:31b,7964,1949,0.9913,90609.6811
+open-ui,5/11/2026, 7:40:03 AM,gemma4:31b,6628,1918,0.8546,90610.6724
+open-ui,5/10/2026, 8:09:08 AM,gemma4:31b,5341,2067,0.7408,90611.5270
+open-ui,5/7/2026, 2:42:48 PM,gemma4:31b,5844,1562,0.7406,90612.2678
+open-ui,5/7/2026, 2:30:26 PM,gemma4:31b,4064,1498,0.5562,90613.0084
+open-ui,5/7/2026, 2:27:12 PM,gemma4:31b,2287,1492,0.3779,90613.5646
+open-ui,5/7/2026, 2:22:06 PM,gemma4:31b,293,1705,0.1998,90613.9425
+open-ui,5/7/2026, 11:57:09 AM,Qwen3-8B-Q4_K_M.gguf,8322,2190,1.0512,90614.1423
+open-ui,5/7/2026, 11:56:13 AM,ministral-3:latest,6446,1711,0.8157,90615.1935
+open-ui,5/7/2026, 11:43:36 AM,Qwen3-8B-Q4_K_M.gguf,1990,663,0.2653,90616.0092
+open-ui,5/7/2026, 11:42:53 AM,Qwen3-8B-Q4_K_M.gguf,752,1225,0.1977,90616.2745
+open-ui,5/7/2026, 11:38:41 AM,ministral-3:latest,3531,1129,0.4660,90616.4722
+open-ui,5/7/2026, 11:36:50 AM,Qwen3-8B-Q4_K_M.gguf,2740,1216,0.3956,90616.9382
+open-ui,5/7/2026, 11:35:41 AM,Qwen3-8B-Q4_K_M.gguf,1300,1418,0.2718,90617.3338
+open-ui,5/7/2026, 11:35:24 AM,Qwen3-8B-Q4_K_M.gguf,378,908,0.1286,90617.6056
+Maged,5/6/2026, 11:20:42 AM,gemma4:31b,256,182,0.0438,49.8641
+Maged,5/6/2026, 11:04:14 AM,gpt-oss-custom:latest,141,196,0.0337,49.9079
+Maged,5/6/2026, 11:02:12 AM,viewpoint-local,207,56,0.0079,49.9416
+Maged,5/6/2026, 11:02:06 AM,viewpoint-local,132,69,0.0060,49.9495
+open-ui,5/5/2026, 9:27:52 AM,gemma4:31b,16294,1388,1.7682,90617.7342
+open-ui,5/5/2026, 9:15:17 AM,gemma4:31b,14614,1629,1.6243,90619.5024
+open-ui,5/5/2026, 9:10:25 AM,gemma4:31b,13305,1186,1.4491,90621.1267
+open-ui,5/5/2026, 8:50:05 AM,gemma4:31b,11404,1760,1.3164,90622.5758
+open-ui,5/5/2026, 8:46:50 AM,gemma4:31b,9777,1609,1.1386,90623.8922
+open-ui,5/5/2026, 8:39:56 AM,gemma4:31b,8168,1573,0.9741,90625.0308
+open-ui,5/5/2026, 7:56:10 AM,gemma4:31b,6804,1233,0.8037,90626.0049
+open-ui,5/5/2026, 5:38:27 AM,gemma4:31b,4864,1915,0.6779,90626.8086
+open-ui,5/5/2026, 5:35:39 AM,gemma4:31b,2739,2089,0.4828,90627.4865
+open-ui,5/4/2026, 12:14:44 PM,ministral-3:latest,1034,547,0.1581,90627.9693
+Praveenkumar Karunakaran,4/30/2026, 11:25:59 AM,gemma4:31b,2370,1576,0.3946,900.6826
+Praveenkumar Karunakaran,4/30/2026, 11:21:55 AM,gemma4:31b,58,2253,0.2311,901.0772
+Philipp Baer,4/30/2026, 9:32:17 AM,image-generation,774,573,0.1347,999.6538
+Philipp Baer,4/30/2026, 9:31:40 AM,image-generation,872,383,0.1255,999.7885
+open-ui,4/30/2026, 9:30:44 AM,image-generation,277,413,0.0690,90628.1274
+open-ui,4/30/2026, 9:29:59 AM,image-generation,12,216,0.0228,90628.1964
+open-ui,4/30/2026, 9:29:33 AM,image-generation,12,263,0.0275,90628.2192
+Philipp Baer,4/30/2026, 9:27:35 AM,image-generation,547,313,0.0860,999.9140
+Praveenkumar Karunakaran,4/30/2026, 9:08:41 AM,gemma4:31b,22,990,0.1012,901.3083
+Praveenkumar Karunakaran,4/29/2026, 2:50:19 PM,gemma4:31b,4799,1626,0.6425,901.4095
+Praveenkumar Karunakaran,4/29/2026, 2:35:19 PM,gemma4:31b,19,1091,0.1110,902.0520
+Praveenkumar Karunakaran,4/29/2026, 2:32:38 PM,gemma4:31b,1637,1591,0.3228,902.1630
+Praveenkumar Karunakaran,4/29/2026, 2:22:18 PM,gemma4:31b,1619,1545,0.3164,902.4858
+Praveenkumar Karunakaran,4/29/2026, 2:13:01 PM,gemma4:31b,1606,1255,0.2861,902.8022
+Praveenkumar Karunakaran,4/29/2026, 2:02:43 PM,gemma4:31b,24,1562,0.1586,903.0883
+open-ui,4/29/2026, 11:31:21 AM,gemma4:31b,324,1406,0.1730,90628.2467
+Praveenkumar Karunakaran,4/28/2026, 4:02:04 PM,gemma4:31b,21,790,0.0811,903.2469
+open-ui,4/27/2026, 11:03:35 AM,gemma4:31b,25732,1841,2.7573,90628.4197
+open-ui,4/27/2026, 9:04:15 AM,gemma4:31b,24016,1683,2.5699,90631.1770
+open-ui,4/24/2026, 1:27:55 PM,gemma4:31b,22546,1451,2.3997,90633.7469
+open-ui,4/24/2026, 1:13:44 PM,gemma4:31b,21000,1526,2.2526,90636.1466
+open-ui,4/24/2026, 12:50:21 PM,gemma4:31b,19666,1313,2.0979,90638.3992
+open-ui,4/24/2026, 12:43:02 PM,gemma4:31b,17868,1781,1.9649,90640.4971
+open-ui,4/24/2026, 12:40:35 PM,gemma4:31b,15952,1893,1.7845,90642.4620
+open-ui,4/24/2026, 12:24:42 PM,gemma4:31b,14073,1854,1.5927,90644.2465
+open-ui,4/24/2026, 12:21:23 PM,gemma4:31b,12306,1723,1.4029,90645.8392
+Uday Kumar,4/24/2026, 3:21:29 AM,qwen3.6:latest,20,952,0.0972,999.8204
+open-ui,4/23/2026, 12:08:09 PM,gpt-oss-custom:latest,17156,2372,1.9528,90647.2421
+open-ui,4/23/2026, 12:06:45 PM,gpt-oss-custom:latest,15266,1848,1.7114,90649.1949
+open-ui,4/23/2026, 12:04:36 PM,gpt-oss-custom:latest,12576,2660,1.5236,90650.9063
+open-ui,4/23/2026, 11:55:31 AM,gpt-oss-custom:latest,10378,2181,1.2559,90652.4299
+open-ui,4/23/2026, 11:46:32 AM,gpt-oss-custom:latest,9039,1303,1.0342,90653.6858
+open-ui,4/23/2026, 11:44:05 AM,gpt-oss-custom:latest,6589,2438,0.9027,90654.7200
+open-ui,4/23/2026, 11:43:31 AM,gpt-oss-custom:latest,4573,1976,0.6549,90655.6227
+open-ui,4/23/2026, 11:38:37 AM,gpt-oss-custom:latest,2945,1616,0.4561,90656.2776
+open-ui,4/23/2026, 11:38:09 AM,gpt-oss-custom:latest,339,2583,0.2922,90656.7337
+open-ui,4/23/2026, 11:26:56 AM,viewpoint-local,3105,546,0.1095,90657.0259
+open-ui,4/23/2026, 11:23:09 AM,viewpoint-local,1137,969,0.0632,90657.1354
+open-ui,4/23/2026, 11:23:02 AM,viewpoint-local,2160,1220,0.1014,90657.1986
+open-ui,4/22/2026, 4:13:51 PM,qwen3.6:latest,4254,2656,0.6910,90657.3000
+open-ui,4/22/2026, 4:12:29 PM,qwen3.6:latest,4255,3435,0.7690,90657.9910
+open-ui,4/22/2026, 4:07:46 PM,qwen3.6:latest,4255,3715,0.7970,90658.7600
+open-ui,4/22/2026, 3:29:38 PM,qwen3.6:latest,3091,3625,0.6716,90659.5570
+open-ui,4/22/2026, 3:26:07 PM,qwen3.6:latest,2003,5507,0.7510,90660.2286
+open-ui,4/22/2026, 2:59:03 PM,qwen3.6:latest,2160,4314,0.6474,90660.9796
+open-ui,4/21/2026, 5:08:54 PM,qwen3.6:latest,383,3290,0.3673,90661.6270
+Seema Mathew,4/20/2026, 4:17:29 PM,phi4-mini:3.8b,151,94,0.0245,978.0668
+open-ui,4/20/2026, 3:44:14 PM,viewpoint-local,2588,326,0.0874,90661.9943
+open-ui,4/20/2026, 3:41:21 PM,viewpoint-local,4826,584,0.1623,90662.0817
+open-ui,4/20/2026, 3:29:58 PM,gemma4:31b,3038,1477,0.4515,90662.2440
+Seema Mathew,4/20/2026, 3:11:28 PM,viewpoint-local,233,42,0.0083,978.0913
+Seema Mathew,4/20/2026, 3:04:36 PM,viewpoint-local,181,40,0.0066,978.0996
+Seema Mathew,4/20/2026, 3:01:42 PM,viewpoint-local,120,38,0.0047,978.1062
+open-ui,4/20/2026, 1:12:15 PM,gemma4:31b,1799,1208,0.3007,90662.6955
+open-ui,4/20/2026, 1:09:20 PM,gemma4:31b,234,1518,0.1752,90662.9962
+open-ui,4/20/2026, 8:47:17 AM,ministral-3:latest,195,978,0.1173,90663.1714
+open-ui,4/20/2026, 8:20:37 AM,ministral-3:latest,57,123,0.0180,90663.2887
+open-ui,4/20/2026, 8:13:02 AM,ministral-3:latest,9,42,0.0051,90663.3067
+Seema Mathew,4/20/2026, 6:35:10 AM,ministral-3:latest,43742,68975,11.2717,978.1109
+Seema Mathew,4/20/2026, 5:11:34 AM,ministral-3:latest,22485,862,2.3347,989.3826
+open-ui,4/17/2026, 2:32:51 PM,gemma4:31b,3525,1589,0.5114,90663.3118
+open-ui,4/17/2026, 2:29:24 PM,gemma4:31b,1394,1738,0.3132,90663.8232
+open-ui,4/17/2026, 8:56:08 AM,viewpoint-local,5516,528,0.1813,90664.1364
+open-ui,4/17/2026, 8:08:49 AM,gemma4:31b,2522,1181,0.3703,90664.3177
+open-ui,4/17/2026, 8:04:55 AM,gemma4:31b,1336,1160,0.2496,90664.6880
+open-ui,4/17/2026, 8:00:54 AM,gemma4:31b,98,1215,0.1313,90664.9376
+open-ui,4/16/2026, 1:43:01 PM,gemma4:31b,291,1844,0.2135,90665.0689
+open-ui,4/16/2026, 11:46:20 AM,image-generation,287,442,0.0729,90665.2824
+open-ui,4/14/2026, 7:42:20 AM,viewpoint-polarion,600,88,0.0688,90665.3553
+Praveenkumar Karunakaran,4/13/2026, 2:12:59 PM,gemma4:31b,34,2022,0.2056,903.3280
+Praveenkumar Karunakaran,4/13/2026, 2:11:00 PM,gemma4:31b,30,1636,0.1666,903.5336
+Praveenkumar Karunakaran,4/13/2026, 8:43:22 AM,gemma4:31b,49,1397,0.1446,903.7002
+Praveenkumar Karunakaran,4/13/2026, 8:23:55 AM,qwen3.5:27b,11,103,0.0114,903.8448
+Uday Kumar,4/13/2026, 7:47:03 AM,viewpoint-polarion,549,275,0.0824,999.9176
+Praveenkumar Karunakaran,4/9/2026, 12:46:33 PM,qwen3.5:27b,11,613,0.0624,903.8562
+Praveenkumar Karunakaran,4/9/2026, 12:37:59 PM,qwen3.5:27b,11,477,0.0488,903.9186
+open-ui,4/9/2026, 9:42:23 AM,ministral-3:latest,499,79,0.0578,90665.4241
+open-ui,4/9/2026, 9:38:04 AM,ministral-3:latest,767,717,0.1484,90665.4819
+open-ui,4/9/2026, 9:36:25 AM,ministral-3:latest,9812,1041,1.0853,90665.6303
+open-ui,4/9/2026, 9:26:29 AM,ministral-3:latest,6070,60,0.6130,90666.7156
+open-ui,4/9/2026, 9:16:19 AM,ministral-3:latest,129,616,0.0745,90667.3286
+open-ui,4/9/2026, 9:15:35 AM,ministral-3:latest,6070,77,0.6147,90667.4031
+Seema Mathew,4/8/2026, 11:53:23 AM,ministral-3:3b,2884,72,0.2956,991.7173
+Seema Mathew,4/8/2026, 11:52:43 AM,ministral-3:3b,2570,15,0.2585,992.0129
+Seema Mathew,4/8/2026, 11:51:54 AM,ministral-3:3b,2334,17,0.2351,992.2714
+Seema Mathew,4/8/2026, 11:49:03 AM,ministral-3:3b,2073,39,0.2112,992.5065
+Seema Mathew,4/8/2026, 11:47:51 AM,ministral-3:3b,1797,27,0.1824,992.7177
+Seema Mathew,4/8/2026, 11:46:56 AM,ministral-3:3b,1495,44,0.1539,992.9001
+Seema Mathew,4/8/2026, 11:44:52 AM,ministral-3:3b,1469,42,0.1511,993.0540
+Seema Mathew,4/8/2026, 10:40:49 AM,ministral-3:3b,1170,52,0.1222,993.2051
+Seema Mathew,4/8/2026, 10:40:02 AM,ministral-3:3b,1165,53,0.1218,993.3273
+Seema Mathew,4/8/2026, 10:39:00 AM,ministral-3:3b,1165,53,0.1218,993.4491
+Seema Mathew,4/8/2026, 10:37:47 AM,ministral-3:3b,1154,53,0.1207,993.5709
+Seema Mathew,4/8/2026, 10:34:55 AM,ministral-3:3b,816,98,0.0914,993.6916
+Seema Mathew,4/8/2026, 10:33:17 AM,ministral-3:3b,792,99,0.0891,993.7830
+Seema Mathew,4/8/2026, 10:31:21 AM,ministral-3:3b,775,99,0.0874,993.8721
+Seema Mathew,4/8/2026, 10:30:18 AM,ministral-3:3b,781,113,0.0894,993.9595
+Seema Mathew,4/8/2026, 10:29:05 AM,ministral-3:3b,787,122,0.0909,994.0489
+Seema Mathew,4/8/2026, 10:28:01 AM,ministral-3:3b,777,108,0.0885,994.1398
+Seema Mathew,4/8/2026, 10:26:46 AM,ministral-3:3b,765,109,0.0874,994.2283
+Seema Mathew,4/8/2026, 10:15:13 AM,ministral-3:3b,723,121,0.0844,994.3157
+Seema Mathew,4/8/2026, 10:13:18 AM,ministral-3:3b,679,230,0.0909,994.4001
+Seema Mathew,4/7/2026, 3:26:34 PM,ministral-3:latest,1946,44,0.1990,994.4910
+open-ui,4/7/2026, 3:26:34 PM,ministral-3:latest,146,174,0.0320,90668.0178
+open-ui,4/7/2026, 3:23:57 PM,qwen3.5:9b,2300,1259,0.3559,90668.0498
+open-ui,4/7/2026, 3:15:57 PM,qwen3.5:9b,1562,722,0.2284,90668.4057
+open-ui,4/7/2026, 3:14:59 PM,qwen3.5:9b,573,900,0.1473,90668.6341
+Praveenkumar Karunakaran,4/7/2026, 11:08:39 AM,qwen3.5:9b,11,259,0.0270,903.9674
+open-ui,4/2/2026, 4:02:36 PM,qwen3.5:9b,544,347,0.0891,90668.7814
+open-ui,4/2/2026, 4:00:13 PM,qwen3.5:9b,68,453,0.0521,90668.8705
+open-ui,4/2/2026, 3:58:42 PM,qwen3.5:9b,349,231,0.0580,90668.9226
+open-ui,4/2/2026, 3:52:55 PM,qwen3.5:9b,349,296,0.0645,90668.9806
+open-ui,4/2/2026, 3:52:12 PM,qwen3.5:9b,349,276,0.0625,90669.0451
+open-ui,4/2/2026, 3:51:53 PM,ministral-3:3b,333,425,0.0758,90669.1076
+open-ui,4/2/2026, 3:49:31 PM,qwen3.5:9b,68,309,0.0377,90669.1834
+Praveenkumar Karunakaran,4/2/2026, 3:40:27 PM,qwen3.5:9b,11,323,0.0334,903.9944
+Seema Mathew,4/2/2026, 12:16:34 PM,ministral-3:latest,549,1366,0.1915,994.6900
+open-ui,4/2/2026, 11:51:33 AM,qwen3.5:9b,59,436,0.0495,90669.2211
+open-ui,4/1/2026, 12:55:47 PM,qwen3.5:9b,20,427,0.0447,90669.2706
+open-ui,3/30/2026, 2:31:47 PM,viewpoint-jira,5197,331,0.1890,90669.3153
+open-ui,3/30/2026, 2:30:36 PM,viewpoint-polarion,1004,170,0.1174,90669.5043
+open-ui,3/30/2026, 2:24:31 PM,viewpoint-polarion,20,350,0.0370,90669.6217
+open-ui,3/30/2026, 1:55:35 PM,viewpoint-polarion,20,398,0.0418,90669.6587
+open-ui,3/30/2026, 1:54:53 PM,viewpoint-polarion,24,457,0.0481,90669.7005
+open-ui,3/30/2026, 1:53:51 PM,viewpoint-polarion,140,1299,0.1439,90669.7486
+open-ui,3/30/2026, 1:36:51 PM,viewpoint-polarion,1468,1253,0.2721,90669.8925
+open-ui,3/30/2026, 1:11:38 PM,viewpoint-polarion,708,751,0.1459,90670.1646
+open-ui,3/30/2026, 1:10:58 PM,viewpoint-polarion,17,676,0.0693,90670.3105
+open-ui,3/30/2026, 12:59:23 PM,viewpoint-polarion,441,1471,0.1912,90670.3798
+open-ui,3/30/2026, 12:58:40 PM,viewpoint-polarion,140,447,0.0587,90670.5710
+open-ui,3/30/2026, 8:46:10 AM,ministral-3:latest,9,77,0.0086,90670.6297
+Praveenkumar Karunakaran,3/27/2026, 11:11:21 AM,qwen3.5:9b,25,4704,0.4729,904.0278
+Praveenkumar Karunakaran,3/27/2026, 10:04:16 AM,qwen3.5:9b,11,163,0.0174,904.5007
+open-ui,3/24/2026, 7:58:08 AM,ministral-3-nano:3b,402,489,0.0891,90670.6383
+Seema Mathew,3/23/2026, 9:14:39 AM,ministral-3:latest,555,219,0.0774,994.8815
+open-ui,3/20/2026, 1:26:33 PM,ministral-3-nano:3b,256,127,0.0383,90670.7274
+Seema Mathew,3/18/2026, 12:52:09 PM,ministral-3:3b,3052,959,0.4011,994.9589
+Seema Mathew,3/18/2026, 8:35:39 AM,ministral-3-nano:3b,4096,836,0.4932,995.3600
+open-ui,3/18/2026, 8:33:16 AM,ministral-3-nano:3b,19,5,0.0024,90670.7657
+Seema Mathew,3/18/2026, 4:26:06 AM,ministral-3-nano:3b,4096,546,0.4642,995.8532
+open-ui,3/13/2026, 10:07:03 AM,gpt-oss-custom:latest,456,1729,0.2185,90670.7681
+Seema Mathew,3/13/2026, 6:23:36 AM,ministral-3:latest,4007,995,0.5002,996.3174
+Seema Mathew,3/13/2026, 6:21:04 AM,ministral-3:latest,3227,745,0.3972,996.8176
+Seema Mathew,3/13/2026, 5:58:59 AM,ministral-3:latest,2188,937,0.3125,997.2148
+Seema Mathew,3/13/2026, 5:55:47 AM,ministral-3:latest,1247,859,0.2106,997.5273
+Seema Mathew,3/13/2026, 5:50:21 AM,ministral-3:latest,550,266,0.0816,997.7379
+Seema Mathew,3/13/2026, 5:47:14 AM,ministral-3:3b,564,404,0.0968,997.8195
+open-ui,3/6/2026, 11:44:37 AM,qwen3.5:9b,1221,913,0.2134,90670.9866
+open-ui,3/5/2026, 11:05:05 AM,qwen3.5:9b,208,1273,0.1481,90671.2000
+Praveenkumar Karunakaran,3/3/2026, 2:00:30 PM,qwen3.5:9b,21,2097,0.2118,904.5181
+open-ui,3/3/2026, 10:33:33 AM,qwen3.5:9b,47,716,0.0763,90671.3481
+open-ui,3/3/2026, 10:32:00 AM,qwen3.5:9b,20,277,0.0297,90671.4244
+open-ui,2/27/2026, 8:51:05 AM,viewpoint-local,5627,869,0.1949,90671.4541
+open-ui,2/27/2026, 8:51:05 AM,viewpoint-local,5627,869,0.1949,90671.6490
+Praveenkumar Karunakaran,2/26/2026, 1:56:25 PM,nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8,420,1962,0.2382,904.7299
+Praveenkumar Karunakaran,2/17/2026, 9:03:22 AM,nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8,11,1308,0.1319,904.9681
+Philipp A. Baer,2/13/2026, 8:39:24 AM,viewpoint-local,132,1830,0.0589,38.6147
+Unknown User,2/9/2026, 12:55:09 PM,qwen3-vl:4b,4034,2785,0.6819,997.2802
+Unknown User,2/9/2026, 12:37:15 PM,qwen3-vl:4b,4423,3503,0.7926,997.9621
+Unknown User,2/9/2026, 11:46:00 AM,qwen3-vl:4b,4193,2487,0.6680,998.7547
+Unknown User,2/9/2026, 11:44:55 AM,qwen3-vl:4b,4016,1757,0.5773,999.4227
+Praveenkumar Karunakaran,1/23/2026, 5:12:18 PM,nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8,8,4235,0.4243,905.1000
+Seema Mathew,1/22/2026, 6:06:41 AM,ministral-3:latest,1303,196,0.1499,997.9163
+Seema Mathew,1/22/2026, 6:05:03 AM,viewpoint-local,124,169,0.0088,998.0662
+Praveenkumar Karunakaran,1/21/2026, 11:39:25 AM,phi4:14b,723,417,0.1140,905.5243
+Praveenkumar Karunakaran,1/21/2026, 11:36:46 AM,phi4:14b,71,575,0.0646,905.6383
+Praveenkumar Karunakaran,1/14/2026, 3:23:44 PM,nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8,7956,99,0.8055,905.7029
+Praveenkumar Karunakaran,1/14/2026, 3:23:20 PM,nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8,5517,2427,0.7944,906.5084
+Praveenkumar Karunakaran,1/14/2026, 3:21:57 PM,nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8,3121,2367,0.5488,907.3028
+Praveenkumar Karunakaran,1/14/2026, 3:20:50 PM,nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8,22,3096,0.3118,907.8516
+Praveenkumar Karunakaran,1/8/2026, 1:56:07 PM,nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8,777,3138,0.3915,908.1634
+Praveenkumar Karunakaran,1/8/2026, 1:55:45 PM,phi4:14b,758,644,0.1402,908.5549
+Praveenkumar Karunakaran,1/8/2026, 1:54:29 PM,nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8,183,2997,0.3180,908.6951
+Praveenkumar Karunakaran,1/8/2026, 1:54:02 PM,phi4:14b,193,472,0.0665,909.0131
+Praveenkumar Karunakaran,1/8/2026, 12:14:02 PM,nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8,8,1461,0.1469,909.0796
+Praveenkumar Karunakaran,1/8/2026, 11:14:58 AM,nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8,2894,4550,0.7444,909.2265
+Praveenkumar Karunakaran,1/8/2026, 10:37:51 AM,nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8,35,2499,0.2534,909.9709
+Praveenkumar Karunakaran,1/8/2026, 10:22:49 AM,phi4:14b,1725,1,0.1726,910.2243
+Seema Mathew,1/8/2026, 9:38:55 AM,ministral-3:latest,3424,759,0.4183,998.0750
+Seema Mathew,1/8/2026, 9:38:16 AM,viewpoint-local,2842,9243,0.3626,998.4933
+Seema Mathew,1/8/2026, 9:35:58 AM,DeepSeek-R1-Distill-Qwen-7B:latest,2810,1348,0.4158,998.8559
+Seema Mathew,1/8/2026, 9:33:53 AM,ministral-3:latest,3424,924,0.4348,999.2717
+Seema Mathew,1/8/2026, 9:31:36 AM,phi4-mini:3.8b,2717,218,0.2935,999.7065
+Praveenkumar Karunakaran,1/7/2026, 11:56:08 AM,mistral-small-2506:latest,4096,409,0.4505,910.3969
+Praveenkumar Karunakaran,1/7/2026, 9:14:11 AM,DeepSeek-R1-Distill-Qwen-7B:latest,18,1543,0.1561,910.8474
+Praveenkumar Karunakaran,1/7/2026, 9:13:20 AM,nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8,8236,71,0.8307,911.0035
+Praveenkumar Karunakaran,1/7/2026, 9:12:47 AM,nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8,8010,213,0.8223,911.8342
+Praveenkumar Karunakaran,1/7/2026, 9:10:32 AM,nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8,3596,4401,0.7997,912.6565
+Praveenkumar Karunakaran,1/7/2026, 9:07:08 AM,nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8,37,3546,0.3583,913.4562
+Praveenkumar Karunakaran,1/5/2026, 2:27:30 PM,nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8,20,3606,0.3626,913.8145
+Praveenkumar Karunakaran,1/5/2026, 12:50:48 PM,nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8,2973,2542,0.5515,914.1771
+Praveenkumar Karunakaran,1/5/2026, 12:50:32 PM,DeepSeek-R1-Distill-Qwen-7B:latest,1537,1257,0.2794,914.7286
+Praveenkumar Karunakaran,1/5/2026, 12:44:46 PM,nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8,1078,1691,0.2769,915.0080
+Praveenkumar Karunakaran,1/5/2026, 12:44:42 PM,DeepSeek-R1-Distill-Qwen-7B:latest,573,889,0.1462,915.2849
+Praveenkumar Karunakaran,1/5/2026, 12:42:31 PM,nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8,11,3692,0.3703,915.4311
+Praveenkumar Karunakaran,1/5/2026, 12:42:02 PM,DeepSeek-R1-Distill-Qwen-7B:latest,14,945,0.0959,915.8014
+Praveenkumar Karunakaran,1/5/2026, 12:17:38 PM,nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8,6,2469,0.2475,915.8973
+Praveenkumar Karunakaran,1/2/2026, 2:45:19 PM,DeepSeek-R1-Distill-Qwen-7B:latest,4096,1800,0.5896,916.1448
+Praveenkumar Karunakaran,1/2/2026, 2:39:54 PM,DeepSeek-R1-Distill-Qwen-7B:latest,4096,1132,0.5228,916.7344
+Praveenkumar Karunakaran,1/2/2026, 2:36:18 PM,DeepSeek-R1-Distill-Qwen-7B:latest,3393,1149,0.4542,917.2572
+Praveenkumar Karunakaran,1/2/2026, 2:35:51 PM,nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8,8216,163,0.8379,917.7114
+Praveenkumar Karunakaran,1/2/2026, 2:34:21 PM,nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8,7969,225,0.8194,918.5493
+Praveenkumar Karunakaran,1/2/2026, 2:33:38 PM,nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8,7969,230,0.8199,919.3687
+Praveenkumar Karunakaran,1/2/2026, 2:16:45 PM,nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8,4376,3583,0.7959,920.1886
+Praveenkumar Karunakaran,1/2/2026, 2:11:22 PM,nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8,7690,79,0.7769,920.9845
+Praveenkumar Karunakaran,1/2/2026, 2:11:05 PM,nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8,3307,4376,0.7683,921.7614
+Praveenkumar Karunakaran,1/2/2026, 1:46:13 PM,nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8,294,929,0.1223,922.5297
+Praveenkumar Karunakaran,1/2/2026, 1:45:26 PM,nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8,5,278,0.0283,922.6520
+Praveenkumar Karunakaran,1/2/2026, 11:56:30 AM,nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8,8,2693,0.2701,922.6803
+Praveenkumar Karunakaran,12/23/2025, 3:02:19 PM,nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8,18,2632,0.2650,922.9504
+Martin Haunschild,12/22/2025, 11:08:22 AM,nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8,5418,3259,0.8677,996.6416
+Martin Haunschild,12/22/2025, 10:59:17 AM,nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8,20,5367,0.5387,997.5093
+Praveenkumar Karunakaran,12/19/2025, 1:15:05 PM,nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8,7895,571,0.8466,923.2154
+Praveenkumar Karunakaran,12/19/2025, 1:08:55 PM,nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8,5135,2752,0.7887,924.0620
+Praveenkumar Karunakaran,12/18/2025, 3:31:23 PM,nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8,12,4607,0.4619,924.8507
+Praveenkumar Karunakaran,12/18/2025, 3:23:55 PM,nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8,1904,4158,0.6062,925.3126
+Praveenkumar Karunakaran,12/18/2025, 3:22:52 PM,SmolLM3-3B:latest,1792,58,0.1850,925.9188
+Praveenkumar Karunakaran,12/18/2025, 3:21:59 PM,SmolLM3-3B:latest,1016,753,0.1769,926.1038
+Praveenkumar Karunakaran,12/18/2025, 3:20:43 PM,SmolLM3-3B:latest,933,60,0.0993,926.2807
+Praveenkumar Karunakaran,12/18/2025, 3:15:47 PM,SmolLM3-3B:latest,4096,701,0.4797,926.3800
+Praveenkumar Karunakaran,12/18/2025, 3:15:11 PM,SmolLM3-3B:latest,1336,165,0.1501,926.8597
+Praveenkumar Karunakaran,12/17/2025, 3:42:40 PM,phi4:14b,3554,552,0.4106,927.0098
+Praveenkumar Karunakaran,12/17/2025, 3:03:16 PM,phi4:14b,1885,734,0.2619,927.4204
+Praveenkumar Karunakaran,12/17/2025, 3:02:37 PM,phi4:14b,1380,484,0.1864,927.6823
+Praveenkumar Karunakaran,12/17/2025, 3:01:18 PM,phi4:14b,780,566,0.1346,927.8687
+Praveenkumar Karunakaran,12/17/2025, 3:01:02 PM,phi4:14b,125,640,0.0765,928.0033
+Praveenkumar Karunakaran,12/17/2025, 2:12:16 PM,phi4:14b,3761,708,0.4469,928.0798
+Praveenkumar Karunakaran,12/17/2025, 2:10:57 PM,phi4:14b,3618,808,0.4426,928.5267
+Praveenkumar Karunakaran,12/17/2025, 2:09:39 PM,phi4:14b,3589,630,0.4219,928.9693
+Praveenkumar Karunakaran,12/17/2025, 2:07:33 PM,phi4:14b,2827,700,0.3527,929.3912
+Praveenkumar Karunakaran,12/17/2025, 2:03:38 PM,phi4:14b,2067,708,0.2775,929.7439
+Praveenkumar Karunakaran,12/17/2025, 2:01:07 PM,phi4:14b,1405,640,0.2045,930.0214
+Praveenkumar Karunakaran,12/17/2025, 1:58:51 PM,phi4:14b,652,674,0.1326,930.2259
+Praveenkumar Karunakaran,12/17/2025, 1:58:15 PM,phi4:14b,31,605,0.0636,930.3585
+Praveenkumar Karunakaran,12/17/2025, 10:55:08 AM,phi4:14b,3730,610,0.4340,930.4221
+Praveenkumar Karunakaran,12/17/2025, 10:54:31 AM,phi4:14b,3530,781,0.4311,930.8561
+Praveenkumar Karunakaran,12/17/2025, 10:53:57 AM,phi4:14b,2506,884,0.3390,931.2872
+Praveenkumar Karunakaran,12/17/2025, 10:52:39 AM,phi4:14b,1673,800,0.2473,931.6262
+Praveenkumar Karunakaran,12/17/2025, 10:49:26 AM,phi4:14b,730,786,0.1516,931.8735
+Praveenkumar Karunakaran,12/17/2025, 10:42:30 AM,phi4:14b,173,535,0.0708,932.0251
+Praveenkumar Karunakaran,12/17/2025, 10:18:50 AM,phi4:14b,35,696,0.0731,932.0959
+Praveenkumar Karunakaran,12/17/2025, 10:17:11 AM,phi4:14b,3093,663,0.3756,932.1690
+Praveenkumar Karunakaran,12/16/2025, 4:21:25 PM,phi4:14b,30,874,0.0904,932.5446
+open-ui,12/16/2025, 2:10:29 PM,nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8,1698,469,0.2167,90671.8439
+Praveenkumar Karunakaran,12/16/2025, 2:05:35 PM,phi4:14b,26,804,0.0830,932.6350
+open-ui,12/16/2025, 1:57:56 PM,ministral-3:latest,60,821,0.0881,90672.0606
+open-ui,12/16/2025, 1:57:43 PM,ministral-3:latest,10,41,0.0051,90672.1487
+open-ui,12/16/2025, 1:57:14 PM,ministral-3:latest,955,592,0.1547,90672.1538
+Praveenkumar Karunakaran,12/16/2025, 1:50:33 PM,Qwen3-4B-toolcalling:latest,68,34,0.0102,932.7180
+Praveenkumar Karunakaran,12/16/2025, 1:50:15 PM,Qwen3-4B-toolcalling:latest,20,22,0.0042,932.7282
+Praveenkumar Karunakaran,12/16/2025, 1:49:53 PM,Qwen3-4B-toolcalling:latest,579,24,0.0603,932.7324
+Praveenkumar Karunakaran,12/16/2025, 1:49:53 PM,phi4:14b,548,402,0.0950,932.7927
+Praveenkumar Karunakaran,12/16/2025, 1:49:42 PM,ministral-3:latest,1074,167,0.1241,932.8877
+Praveenkumar Karunakaran,12/16/2025, 1:48:52 PM,Qwen3-4B-toolcalling:latest,4096,25,0.4121,933.0118
+Praveenkumar Karunakaran,12/16/2025, 1:47:59 PM,ministral-3:latest,573,24,0.0597,933.4239
+Praveenkumar Karunakaran,12/16/2025, 1:47:57 PM,phi4:14b,51,24,0.0075,933.4836
+Praveenkumar Karunakaran,12/16/2025, 1:46:18 PM,phi4:14b,11,28,0.0039,933.4911
+open-ui,12/16/2025, 1:39:31 PM,nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8,125,919,0.1044,90672.3085
+open-ui,12/16/2025, 1:39:16 PM,nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8,3,112,0.0115,90672.4129
+open-ui,12/16/2025, 1:36:14 PM,nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8,1,45,0.0046,90672.4244
+open-ui,12/16/2025, 1:23:23 PM,nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8,374,2564,0.2938,90672.4290
+open-ui,12/16/2025, 12:52:40 PM,nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8,1,325,0.0326,90672.7228
+open-ui,12/16/2025, 12:52:14 PM,ministral-3:latest,2522,767,0.3289,90672.7554
+Praveenkumar Karunakaran,12/16/2025, 12:12:07 PM,ministral-3:latest,555,1059,0.1614,933.4950
+Martin Haunschild,12/12/2025, 1:44:14 PM,ministral-3:latest,2485,807,0.3292,998.0480
+Praveenkumar Karunakaran,12/12/2025, 11:57:18 AM,Qwen3-30B-A3B:latest,2809,1257,0.4066,933.6564
+Praveenkumar Karunakaran,12/12/2025, 11:52:57 AM,Qwen3-30B-A3B:latest,1431,1236,0.2667,934.0630
+Praveenkumar Karunakaran,12/12/2025, 11:51:25 AM,Qwen3-30B-A3B:latest,252,1117,0.1369,934.3297
+Praveenkumar Karunakaran,12/11/2025, 3:56:27 PM,Qwen3-30B-A3B:latest,3229,1518,0.4747,934.4666
+Praveenkumar Karunakaran,12/11/2025, 3:54:16 PM,Qwen3-30B-A3B:latest,3296,1366,0.4662,934.9413
+Praveenkumar Karunakaran,12/11/2025, 3:46:51 PM,Qwen3-30B-A3B:latest,1560,1656,0.3216,935.4075
+Praveenkumar Karunakaran,12/11/2025, 3:45:53 PM,Qwen3-30B-A3B:latest,140,1308,0.1448,935.7291
+Praveenkumar Karunakaran,12/11/2025, 3:39:36 PM,Qwen3-30B-A3B:latest,3103,1471,0.4574,935.8739
+Praveenkumar Karunakaran,12/11/2025, 3:10:36 PM,Qwen3-30B-A3B:latest,1457,1620,0.3077,936.3313
+Praveenkumar Karunakaran,12/11/2025, 3:04:34 PM,Qwen3-30B-A3B:latest,18,1378,0.1396,936.6390
+Praveenkumar Karunakaran,12/11/2025, 12:00:22 PM,Qwen3-30B-A3B:latest,4033,1883,0.5916,936.7786
+Praveenkumar Karunakaran,12/11/2025, 11:47:24 AM,Qwen3-30B-A3B:latest,2751,1245,0.3996,937.3702
+Praveenkumar Karunakaran,12/11/2025, 11:45:54 AM,Qwen3-30B-A3B:latest,1167,1472,0.2639,937.7698
+Praveenkumar Karunakaran,12/11/2025, 11:42:53 AM,Qwen3-30B-A3B:latest,48,1096,0.1144,938.0337
+Praveenkumar Karunakaran,12/11/2025, 11:24:22 AM,Qwen3-30B-A3B:latest,16,2625,0.2641,938.1481
+Praveenkumar Karunakaran,12/11/2025, 9:37:48 AM,Qwen3-30B-A3B:latest,21,882,0.0903,938.4122
+Praveenkumar Karunakaran,12/11/2025, 9:17:23 AM,Qwen3-30B-A3B:latest,27,1347,0.1374,938.5025
+Praveenkumar Karunakaran,12/10/2025, 5:50:36 PM,Qwen3-30B-A3B:latest,3615,794,0.4409,938.6399
+Praveenkumar Karunakaran,12/10/2025, 5:49:55 PM,Qwen3-30B-A3B:latest,3434,1298,0.4732,939.0808
+Praveenkumar Karunakaran,12/10/2025, 5:48:28 PM,Qwen3-30B-A3B:latest,2835,1276,0.4111,939.5540
+Praveenkumar Karunakaran,12/10/2025, 5:47:40 PM,Qwen3-30B-A3B:latest,3346,974,0.4320,939.9651
+Praveenkumar Karunakaran,12/10/2025, 5:46:27 PM,Qwen3-30B-A3B:latest,2525,672,0.3197,940.3971
+Praveenkumar Karunakaran,12/10/2025, 5:44:47 PM,Qwen3-30B-A3B:latest,3637,1499,0.5136,940.7168
+Praveenkumar Karunakaran,12/10/2025, 5:43:05 PM,ministral-3:latest,2618,1821,0.4439,941.2304
+Praveenkumar Karunakaran,12/10/2025, 5:40:03 PM,ministral-3:latest,1663,926,0.2589,941.6743
+Praveenkumar Karunakaran,12/10/2025, 5:38:46 PM,ministral-3:latest,554,1083,0.1637,941.9332
+Praveenkumar Karunakaran,12/10/2025, 5:23:20 PM,Qwen3-30B-A3B:latest,1811,1192,0.3003,942.0969
+Praveenkumar Karunakaran,12/10/2025, 5:22:01 PM,Qwen3-30B-A3B:latest,4041,1760,0.5801,942.3972
+Praveenkumar Karunakaran,12/10/2025, 5:17:54 PM,Qwen3-30B-A3B:latest,1707,2312,0.4019,942.9773
+Praveenkumar Karunakaran,12/10/2025, 5:12:49 PM,Qwen3-30B-A3B:latest,2467,1649,0.4116,943.3792
+Praveenkumar Karunakaran,12/10/2025, 5:11:01 PM,Qwen3-30B-A3B:latest,2117,2424,0.4541,943.7908
+Praveenkumar Karunakaran,12/10/2025, 5:08:41 PM,Qwen3-30B-A3B:latest,3805,2092,0.5897,944.2449
+Praveenkumar Karunakaran,12/10/2025, 3:41:38 PM,Qwen3-30B-A3B:latest,1631,1258,0.2889,944.8346
+Praveenkumar Karunakaran,12/10/2025, 3:41:10 PM,Qwen3-30B-A3B:latest,102,1500,0.1602,945.1235
+Praveenkumar Karunakaran,12/10/2025, 3:04:45 PM,Qwen3-30B-A3B:latest,3958,2119,0.6077,945.2837
+Praveenkumar Karunakaran,12/10/2025, 3:03:35 PM,Qwen3-30B-A3B:latest,2613,1303,0.3916,945.8914
+Praveenkumar Karunakaran,12/10/2025, 3:02:21 PM,Qwen3-30B-A3B:latest,4096,2579,0.6675,946.2830
+Praveenkumar Karunakaran,12/10/2025, 2:58:25 PM,Qwen3-30B-A3B:latest,45,2586,0.2631,946.9505
+Praveenkumar Karunakaran,12/10/2025, 11:19:32 AM,Qwen3-30B-A3B:latest,1686,471,0.2157,947.2136
+Praveenkumar Karunakaran,12/10/2025, 11:16:07 AM,Qwen3-30B-A3B:latest,1378,278,0.1656,947.4293
+Praveenkumar Karunakaran,12/10/2025, 11:14:11 AM,Qwen3-30B-A3B:latest,2805,1293,0.4098,947.5949
+Praveenkumar Karunakaran,12/10/2025, 10:52:01 AM,Qwen3-30B-A3B:latest,2151,2762,0.4913,948.0047
+Praveenkumar Karunakaran,12/10/2025, 10:50:41 AM,Qwen3-30B-A3B:latest,2157,2122,0.4279,948.4960
+Praveenkumar Karunakaran,12/10/2025, 10:48:28 AM,Qwen3-30B-A3B:latest,45,2097,0.2142,948.9239
+Praveenkumar Karunakaran,12/10/2025, 10:44:56 AM,Qwen3-30B-A3B:latest,47,2455,0.2502,949.1381
+Praveenkumar Karunakaran,12/10/2025, 10:42:44 AM,Qwen3-30B-A3B:latest,328,1016,0.1344,949.3883
+Praveenkumar Karunakaran,12/4/2025, 10:35:24 AM,Qwen3-30B-A3B:latest,17,487,0.0504,949.5227
+Praveenkumar Karunakaran,12/3/2025, 2:47:36 PM,Qwen3-30B-A3B:latest,3916,1841,0.5757,949.5731
+Praveenkumar Karunakaran,12/3/2025, 2:45:02 PM,Qwen3-30B-A3B:latest,1765,2122,0.3887,950.1488
+Praveenkumar Karunakaran,12/3/2025, 10:31:08 AM,Qwen3-30B-A3B:latest,761,985,0.1746,950.5375
+Praveenkumar Karunakaran,12/3/2025, 10:26:23 AM,Qwen3-30B-A3B:latest,34,709,0.0743,950.7121
+open-ui,12/3/2025, 10:09:23 AM,ministral-3:latest,2067,635,0.2702,90673.0843
+open-ui,12/3/2025, 10:08:27 AM,ministral-3:latest,2067,642,0.2709,90673.3545
+open-ui,12/3/2025, 10:06:08 AM,viewpoint-jira,4512,168,0.1522,90673.6254
+open-ui,12/3/2025, 10:05:53 AM,viewpoint-jira,4856,129,0.1586,90673.7776
+open-ui,12/3/2025, 10:05:30 AM,viewpoint-jira,8603,193,0.2774,90673.9362
+open-ui,12/3/2025, 10:00:51 AM,viewpoint-jira,4014,33,0.1237,90674.2136
+Martin Haunschild,12/3/2025, 9:53:13 AM,ministral-3:latest,1832,638,0.2470,998.3772
+Martin Haunschild,12/3/2025, 9:46:43 AM,Qwen3-30B-A3B:latest,18,149,0.0167,998.6242
+Praveenkumar Karunakaran,12/2/2025, 5:00:41 PM,Qwen3-30B-A3B:latest,772,1032,0.1804,950.7864
+Praveenkumar Karunakaran,12/2/2025, 4:59:11 PM,Qwen3-30B-A3B:latest,15,740,0.0755,950.9668
+Praveenkumar Karunakaran,12/2/2025, 10:42:04 AM,Qwen3-30B-A3B:latest,3617,1295,0.4912,951.0423
+Praveenkumar Karunakaran,12/2/2025, 10:29:52 AM,Qwen3-30B-A3B:latest,2727,1441,0.4168,951.5335
+Praveenkumar Karunakaran,12/2/2025, 10:25:09 AM,Qwen3-30B-A3B:latest,1445,1254,0.2699,951.9503
+Praveenkumar Karunakaran,12/2/2025, 10:13:14 AM,Qwen3-30B-A3B:latest,588,838,0.1426,952.2202
+Praveenkumar Karunakaran,12/2/2025, 10:12:29 AM,Qwen3-30B-A3B:latest,14,555,0.0569,952.3628
+open-ui,11/27/2025, 1:22:06 PM,viewpoint-jira,3045,2681,0.3595,90674.3373
+open-ui,11/24/2025, 9:55:15 AM,gpt-oss-custom:latest,160,904,0.1064,90674.6968
+open-ui,11/21/2025, 1:31:31 PM,Olmo-3-32B:latest,60,155,0.0215,90674.8032
+open-ui,11/21/2025, 1:26:27 PM,gpt-oss-custom:latest,2853,239,0.3092,90674.8247
+open-ui,11/20/2025, 1:15:52 PM,viewpoint-jira,48139,205,1.4647,90675.1339
+Martin Haunschild,11/18/2025, 1:28:01 PM,gpt-oss:20b,2593,1049,0.3642,998.6409
+Martin Haunschild,11/18/2025, 1:26:50 PM,gpt-oss:20b,2509,675,0.3184,999.0051
+Martin Haunschild,11/18/2025, 1:26:09 PM,gpt-oss:20b,2819,184,0.3003,999.3235
+Martin Haunschild,11/18/2025, 1:24:50 PM,gpt-oss:20b,2821,230,0.3051,999.6238
+open-ui,11/18/2025, 11:33:15 AM,gpt-oss-custom:latest,2640,1161,0.3801,90676.5986
+open-ui,11/18/2025, 11:32:09 AM,gpt-oss-custom:latest,2503,431,0.2934,90676.9787
+open-ui,11/18/2025, 11:31:56 AM,gpt-oss-custom:latest,2857,418,0.3275,90677.2721
+Praveenkumar Karunakaran,10/28/2025, 4:33:46 PM,Qwen3-30B-A3B:latest,2356,1314,0.3670,952.4197
+Praveenkumar Karunakaran,10/28/2025, 3:06:31 PM,Qwen3-30B-A3B:latest,1365,969,0.2334,952.7867
+Praveenkumar Karunakaran,10/28/2025, 1:58:30 PM,Qwen3-30B-A3B:latest,4096,1345,0.5441,953.0201
+Praveenkumar Karunakaran,10/27/2025, 3:12:16 PM,Qwen3-30B-A3B:latest,2676,648,0.3324,953.5642
+Praveenkumar Karunakaran,10/27/2025, 3:11:16 PM,Qwen3-30B-A3B:latest,428,163,0.0591,953.8966
+Praveenkumar Karunakaran,10/27/2025, 12:48:50 PM,Qwen3-30B-A3B:latest,4055,1310,0.5365,953.9557
+Praveenkumar Karunakaran,10/27/2025, 12:47:34 PM,Qwen3-30B-A3B:latest,3429,1130,0.4559,954.4922
+Praveenkumar Karunakaran,10/27/2025, 12:46:38 PM,Qwen3-30B-A3B:latest,3263,1125,0.4388,954.9481
+Praveenkumar Karunakaran,10/27/2025, 12:44:17 PM,Qwen3-30B-A3B:latest,2121,733,0.2854,955.3869
+Praveenkumar Karunakaran,10/27/2025, 12:37:45 PM,Qwen3-30B-A3B:latest,998,1081,0.2079,955.6723
+Praveenkumar Karunakaran,10/27/2025, 10:08:56 AM,Qwen3-30B-A3B:latest,4096,982,0.5078,955.8802
+Praveenkumar Karunakaran,10/23/2025, 12:20:11 PM,Qwen3-30B-A3B:latest,2946,1310,0.4256,956.3880
+Praveenkumar Karunakaran,10/23/2025, 12:16:16 PM,Qwen3-30B-A3B:latest,3814,1065,0.4879,956.8136
+Praveenkumar Karunakaran,10/23/2025, 12:14:03 PM,Qwen3-30B-A3B:latest,3102,1548,0.4650,957.3015
+Praveenkumar Karunakaran,10/23/2025, 12:06:59 PM,Qwen3-30B-A3B:latest,1862,1172,0.3034,957.7665
+Praveenkumar Karunakaran,10/23/2025, 11:58:57 AM,Qwen3-30B-A3B:latest,1820,445,0.2265,958.0699
+Praveenkumar Karunakaran,10/23/2025, 11:57:23 AM,Qwen3-30B-A3B:latest,1335,457,0.1792,958.2964
+Praveenkumar Karunakaran,10/23/2025, 11:55:48 AM,Qwen3-30B-A3B:latest,857,424,0.1281,958.4756
+Praveenkumar Karunakaran,10/23/2025, 11:49:28 AM,Qwen3-30B-A3B:latest,428,405,0.0833,958.6037
+Praveenkumar Karunakaran,10/23/2025, 11:10:36 AM,Qwen3-30B-A3B:latest,543,88,0.0631,958.6870
+Praveenkumar Karunakaran,10/23/2025, 11:09:55 AM,Qwen3-30B-A3B:latest,435,76,0.0511,958.7501
+Praveenkumar Karunakaran,10/23/2025, 10:14:29 AM,Qwen3-30B-A3B:latest,1371,1320,0.2691,958.8012
+Praveenkumar Karunakaran,10/23/2025, 10:12:41 AM,Qwen3-30B-A3B:latest,4096,1345,0.5441,959.0703
+Praveenkumar Karunakaran,10/23/2025, 10:06:19 AM,Qwen3-30B-A3B:latest,4096,708,0.4804,959.6144
+Praveenkumar Karunakaran,10/22/2025, 2:00:40 PM,Qwen3-30B-A3B:latest,4096,1174,0.5270,960.0948
+Praveenkumar Karunakaran,10/22/2025, 12:33:11 PM,Qwen3-30B-A3B:latest,4096,859,0.4955,960.6218
+open-ui,10/17/2025, 1:20:41 PM,Qwen3-30B-A3B:latest,127,628,0.0755,90677.5996
+open-ui,10/17/2025, 1:19:41 PM,Qwen3-30B-A3B:latest,121,147,0.0268,90677.6751
+open-ui,10/17/2025, 1:19:00 PM,Qwen3-30B-A3B:latest,118,187,0.0305,90677.7019
+Praveenkumar Karunakaran,10/16/2025, 9:44:07 AM,Qwen3-30B-A3B:latest,4096,1206,0.5302,961.1173
+Praveenkumar Karunakaran,10/15/2025, 11:48:47 AM,Qwen3-30B-A3B:latest,1141,1476,0.2617,961.6475
+Praveenkumar Karunakaran,10/15/2025, 11:47:14 AM,Qwen3-30B-A3B:latest,4096,1124,0.5220,961.9092
+Praveenkumar Karunakaran,10/13/2025, 2:10:46 PM,Qwen3-30B-A3B:latest,2866,1481,0.4347,962.4312
+Praveenkumar Karunakaran,10/13/2025, 1:43:27 PM,Qwen3-30B-A3B:latest,2828,1373,0.4201,962.8659
+Praveenkumar Karunakaran,10/13/2025, 1:41:47 PM,Qwen3-30B-A3B:latest,1373,1435,0.2808,963.2860
+Praveenkumar Karunakaran,10/13/2025, 1:41:06 PM,Qwen3-30B-A3B:latest,4096,1355,0.5451,963.5668
+Praveenkumar Karunakaran,10/8/2025, 4:31:15 PM,Qwen3-30B-A3B:latest,4096,810,0.4906,964.1119
+Praveenkumar Karunakaran,10/8/2025, 12:52:15 PM,Qwen3-30B-A3B:latest,3945,747,0.4692,964.6025
+Praveenkumar Karunakaran,10/8/2025, 12:51:30 PM,Qwen3-30B-A3B:latest,3796,522,0.4318,965.0717
+Praveenkumar Karunakaran,10/8/2025, 12:50:40 PM,Qwen3-30B-A3B:latest,3115,396,0.3511,965.5035
+Praveenkumar Karunakaran,10/8/2025, 12:49:56 PM,Qwen3-30B-A3B:latest,2313,646,0.2959,965.8546
+Praveenkumar Karunakaran,10/8/2025, 12:46:57 PM,Qwen3-30B-A3B:latest,1288,1019,0.2307,966.1505
+Praveenkumar Karunakaran,10/8/2025, 12:44:49 PM,Qwen3-30B-A3B:latest,4096,862,0.4958,966.3812
+Praveenkumar Karunakaran,10/8/2025, 9:51:34 AM,Qwen3-30B-A3B:latest,3580,1001,0.4581,966.8770
+Praveenkumar Karunakaran,10/8/2025, 9:49:43 AM,Qwen3-30B-A3B:latest,3961,814,0.4775,967.3351
+Praveenkumar Karunakaran,10/8/2025, 9:47:01 AM,Qwen3-30B-A3B:latest,3747,683,0.4430,967.8126
+Praveenkumar Karunakaran,10/8/2025, 9:43:46 AM,Qwen3-30B-A3B:latest,3926,719,0.4645,968.2556
+Praveenkumar Karunakaran,10/8/2025, 9:43:19 AM,Qwen3-30B-A3B:latest,3301,585,0.3886,968.7201
+Praveenkumar Karunakaran,10/8/2025, 9:40:30 AM,Qwen3-30B-A3B:latest,3398,652,0.4050,969.1087
+Praveenkumar Karunakaran,10/8/2025, 9:37:59 AM,Qwen3-30B-A3B:latest,3962,515,0.4477,969.5137
+Praveenkumar Karunakaran,10/8/2025, 9:37:07 AM,Qwen3-30B-A3B:latest,3911,459,0.4370,969.9614
+Praveenkumar Karunakaran,10/8/2025, 9:35:59 AM,Qwen3-30B-A3B:latest,3033,855,0.3888,970.3984
+Praveenkumar Karunakaran,10/8/2025, 9:34:56 AM,Qwen3-30B-A3B:latest,2370,626,0.2996,970.7872
+Praveenkumar Karunakaran,10/8/2025, 9:30:56 AM,Qwen3-30B-A3B:latest,1553,795,0.2348,971.0868
+Praveenkumar Karunakaran,10/8/2025, 9:30:42 AM,Qwen3-30B-A3B:latest,4096,1101,0.5197,971.3216
+Praveenkumar Karunakaran,10/7/2025, 4:59:06 PM,Qwen3-30B-A3B:latest,3926,454,0.4380,971.8413
+Praveenkumar Karunakaran,10/7/2025, 4:55:11 PM,Qwen3-30B-A3B:latest,3474,636,0.4110,972.2793
+Praveenkumar Karunakaran,10/7/2025, 4:52:56 PM,Qwen3-30B-A3B:latest,2425,560,0.2985,972.6903
+Praveenkumar Karunakaran,10/7/2025, 4:51:55 PM,Qwen3-30B-A3B:latest,1912,539,0.2451,972.9888
+Praveenkumar Karunakaran,10/7/2025, 4:49:12 PM,Qwen3-30B-A3B:latest,1303,537,0.1840,973.2339
+Praveenkumar Karunakaran,10/7/2025, 4:45:17 PM,Qwen3-30B-A3B:latest,4096,819,0.4915,973.4179
+Praveenkumar Karunakaran,10/7/2025, 4:10:14 PM,Qwen3-30B-A3B:latest,3755,510,0.4265,973.9094
+Praveenkumar Karunakaran,10/7/2025, 4:09:45 PM,Qwen3-30B-A3B:latest,3217,521,0.3738,974.3359
+Praveenkumar Karunakaran,10/7/2025, 4:08:42 PM,Qwen3-30B-A3B:latest,2683,506,0.3189,974.7097
+Praveenkumar Karunakaran,10/7/2025, 4:07:32 PM,Qwen3-30B-A3B:latest,2245,424,0.2669,975.0286
+Praveenkumar Karunakaran,10/7/2025, 4:06:44 PM,Qwen3-30B-A3B:latest,3972,562,0.4534,975.2955
+Praveenkumar Karunakaran,10/7/2025, 4:00:48 PM,Qwen3-30B-A3B:latest,4085,1588,0.5673,975.7489
+Praveenkumar Karunakaran,10/7/2025, 3:56:53 PM,Qwen3-30B-A3B:latest,3128,2339,0.5467,976.3162
+Praveenkumar Karunakaran,10/7/2025, 3:55:06 PM,Qwen3-30B-A3B:latest,2442,1703,0.4145,976.8629
+Praveenkumar Karunakaran,10/7/2025, 3:52:21 PM,Qwen3-30B-A3B:latest,3922,1382,0.5304,977.2774
+Praveenkumar Karunakaran,10/7/2025, 3:46:55 PM,Qwen3-30B-A3B:latest,2889,1018,0.3907,977.8078
+Praveenkumar Karunakaran,10/7/2025, 3:44:20 PM,Qwen3-30B-A3B:latest,2671,1672,0.4343,978.1985
+Praveenkumar Karunakaran,10/7/2025, 3:40:15 PM,Qwen3-30B-A3B:latest,2989,1175,0.4164,978.6328
+Praveenkumar Karunakaran,10/7/2025, 3:37:36 PM,Qwen3-30B-A3B:latest,2844,1455,0.4299,979.0492
+Praveenkumar Karunakaran,10/7/2025, 3:24:05 PM,Qwen3-30B-A3B:latest,3861,1492,0.5353,979.4791
+Praveenkumar Karunakaran,10/7/2025, 3:22:47 PM,Qwen3-30B-A3B:latest,3503,1307,0.4810,980.0144
+Praveenkumar Karunakaran,10/7/2025, 3:20:41 PM,Qwen3-30B-A3B:latest,3657,1482,0.5139,980.4954
+Praveenkumar Karunakaran,10/7/2025, 2:37:52 PM,Qwen3-30B-A3B:latest,3838,958,0.4796,981.0093
+Praveenkumar Karunakaran,10/7/2025, 2:36:52 PM,Qwen3-30B-A3B:latest,4045,951,0.4996,981.4889
+Praveenkumar Karunakaran,10/7/2025, 2:36:04 PM,Qwen3-30B-A3B:latest,3801,750,0.4551,981.9885
+Praveenkumar Karunakaran,10/7/2025, 2:33:43 PM,Qwen3-30B-A3B:latest,4087,827,0.4914,982.4436
+Praveenkumar Karunakaran,10/7/2025, 2:32:14 PM,Qwen3-30B-A3B:latest,4073,680,0.4753,982.9350
+Praveenkumar Karunakaran,10/7/2025, 2:30:20 PM,Qwen3-30B-A3B:latest,4010,444,0.4454,983.4103
+Praveenkumar Karunakaran,10/7/2025, 2:29:33 PM,Qwen3-30B-A3B:latest,3545,451,0.3996,983.8557
+Praveenkumar Karunakaran,10/7/2025, 2:26:55 PM,Qwen3-30B-A3B:latest,2898,685,0.3583,984.2553
+Praveenkumar Karunakaran,10/7/2025, 2:24:48 PM,Qwen3-30B-A3B:latest,2271,502,0.2773,984.6136
+Praveenkumar Karunakaran,10/7/2025, 2:21:08 PM,Qwen3-30B-A3B:latest,1947,304,0.2251,984.8909
+Praveenkumar Karunakaran,10/7/2025, 2:17:41 PM,Qwen3-30B-A3B:latest,1108,845,0.1953,985.1160
+Praveenkumar Karunakaran,10/7/2025, 2:15:59 PM,Qwen3-30B-A3B:latest,739,312,0.1051,985.3113
+Praveenkumar Karunakaran,10/7/2025, 2:15:30 PM,Qwen3-30B-A3B:latest,4096,328,0.4424,985.4164
+Praveenkumar Karunakaran,10/7/2025, 1:33:55 PM,Qwen3-30B-A3B:latest,1502,193,0.1695,985.8588
+Praveenkumar Karunakaran,10/7/2025, 1:32:50 PM,Qwen3-30B-A3B:latest,1289,216,0.1505,986.0283
+Praveenkumar Karunakaran,10/7/2025, 1:31:16 PM,Qwen3-30B-A3B:latest,989,228,0.1217,986.1788
+Praveenkumar Karunakaran,10/7/2025, 1:29:56 PM,Qwen3-30B-A3B:latest,789,176,0.0965,986.3005
+Praveenkumar Karunakaran,10/7/2025, 1:28:47 PM,Qwen3-30B-A3B:latest,545,238,0.0783,986.3970
+Praveenkumar Karunakaran,10/7/2025, 1:28:22 PM,Qwen3-30B-A3B:latest,401,129,0.0530,986.4753
+Praveenkumar Karunakaran,10/7/2025, 1:14:34 PM,Qwen3-30B-A3B:latest,3162,518,0.3680,986.5283
+Praveenkumar Karunakaran,10/7/2025, 1:13:30 PM,Qwen3-30B-A3B:latest,3700,590,0.4290,986.8963
+Praveenkumar Karunakaran,10/7/2025, 1:12:28 PM,Qwen3-30B-A3B:latest,2897,781,0.3678,987.3253
+Praveenkumar Karunakaran,10/7/2025, 1:10:43 PM,Qwen3-30B-A3B:latest,3505,749,0.4254,987.6931
+Praveenkumar Karunakaran,10/7/2025, 11:40:36 AM,Qwen3-30B-A3B:latest,3455,948,0.4403,988.1185
+Praveenkumar Karunakaran,10/7/2025, 11:39:29 AM,Qwen3-30B-A3B:latest,4064,1130,0.5194,988.5588
+Praveenkumar Karunakaran,10/7/2025, 11:38:43 AM,Qwen3-30B-A3B:latest,3674,1340,0.5014,989.0782
+Praveenkumar Karunakaran,10/7/2025, 11:37:50 AM,Qwen3-30B-A3B:latest,3705,888,0.4593,989.5796
+Praveenkumar Karunakaran,10/7/2025, 11:35:55 AM,Qwen3-30B-A3B:latest,2825,856,0.3681,990.0389
+Praveenkumar Karunakaran,10/7/2025, 11:35:16 AM,Qwen3-30B-A3B:latest,3427,874,0.4301,990.4070
+Praveenkumar Karunakaran,10/7/2025, 11:32:58 AM,Qwen3-30B-A3B:latest,3715,946,0.4661,990.8371
+Praveenkumar Karunakaran,10/7/2025, 11:25:32 AM,Qwen3-30B-A3B:latest,2331,934,0.3265,991.3032
+Praveenkumar Karunakaran,10/7/2025, 11:24:36 AM,Qwen3-30B-A3B:latest,841,1471,0.2312,991.6297
+Praveenkumar Karunakaran,10/7/2025, 11:20:53 AM,Qwen3-30B-A3B:latest,4096,815,0.4911,991.8609
+Praveenkumar Karunakaran,10/6/2025, 4:51:13 PM,Qwen3-30B-A3B:latest,3834,1471,0.5305,992.3520
+Praveenkumar Karunakaran,10/6/2025, 4:41:01 PM,Qwen3-30B-A3B:latest,3344,874,0.4218,992.8825
+Praveenkumar Karunakaran,10/6/2025, 4:32:29 PM,Qwen3-30B-A3B:latest,2466,535,0.3001,993.3043
+Praveenkumar Karunakaran,10/6/2025, 4:32:22 PM,Qwen3-30B-A3B:latest,2461,850,0.3311,993.6044
+Praveenkumar Karunakaran,10/6/2025, 4:20:52 PM,Qwen3-30B-A3B:latest,838,1228,0.2066,993.9355
+Praveenkumar Karunakaran,10/6/2025, 4:20:41 PM,Qwen3-30B-A3B:latest,838,1222,0.2060,994.1421
+Praveenkumar Karunakaran,10/6/2025, 4:01:26 PM,Qwen3-30B-A3B:latest,4096,817,0.4913,994.3481
+Praveenkumar Karunakaran,10/6/2025, 3:33:35 PM,Qwen3-30B-A3B:latest,3970,810,0.4780,994.8394
+Praveenkumar Karunakaran,10/6/2025, 3:14:57 PM,Qwen3-30B-A3B:latest,2468,1416,0.3884,995.3174
+Praveenkumar Karunakaran,10/6/2025, 3:01:43 PM,Qwen3-30B-A3B:latest,2492,2234,0.4726,995.7058
+Praveenkumar Karunakaran,10/6/2025, 2:59:02 PM,Qwen3-30B-A3B:latest,3500,2373,0.5873,996.1784
+Praveenkumar Karunakaran,10/6/2025, 2:55:49 PM,Qwen3-30B-A3B:latest,3804,605,0.4409,996.7657
+Praveenkumar Karunakaran,10/6/2025, 2:32:15 PM,Qwen3-30B-A3B:latest,2372,1019,0.3391,997.2066
+Praveenkumar Karunakaran,10/6/2025, 2:31:08 PM,Qwen3-30B-A3B:latest,1419,542,0.1961,997.5457
+Praveenkumar Karunakaran,10/6/2025, 2:30:35 PM,Qwen3-30B-A3B:latest,268,1133,0.1401,997.7418
+Praveenkumar Karunakaran,10/6/2025, 2:29:54 PM,Qwen3-30B-A3B:latest,405,134,0.0539,997.8819
+Praveenkumar Karunakaran,10/6/2025, 10:59:44 AM,Qwen3-30B-A3B:latest,4096,1175,0.5271,997.9358
+Philipp A. Baer,10/3/2025, 4:15:40 AM,Qwen3-30B-A3B:latest,2337,1870,0.4207,38.6736
+Philipp A. Baer,10/3/2025, 4:14:05 AM,Qwen3-30B-A3B:latest,3605,2277,0.5882,39.0943
+Philipp A. Baer,10/3/2025, 4:13:00 AM,Qwen3-30B-A3B:latest,3783,1817,0.5600,39.6825
+Philipp A. Baer,10/3/2025, 4:10:47 AM,Qwen3-30B-A3B:latest,1789,2006,0.3795,40.2425
+Philipp A. Baer,10/3/2025, 4:09:41 AM,Qwen3-30B-A3B:latest,3153,1750,0.4903,40.6220
+Philipp A. Baer,10/3/2025, 4:08:27 AM,Qwen3-30B-A3B:latest,3302,3112,0.6414,41.1123
+Philipp A. Baer,10/3/2025, 4:06:45 AM,Qwen3-30B-A3B:latest,716,2098,0.2814,41.7537
+open-ui,10/2/2025, 12:19:03 PM,viewpoint-local,6295,1063,0.2207,90677.7324
+Praveenkumar Karunakaran,9/25/2025, 4:56:33 PM,Qwen3-30B-A3B:latest,4096,878,0.4974,998.4629
+Praveenkumar Karunakaran,9/25/2025, 12:05:55 PM,medgemma-4b:latest,4096,651,0.4747,998.9603
+Praveenkumar Karunakaran,9/25/2025, 11:01:08 AM,Qwen3-30B-A3B:latest,62,1320,0.1382,999.4350
+Praveenkumar Karunakaran,9/25/2025, 10:59:08 AM,Qwen3-30B-A3B:latest,12,33,0.0045,999.5732
+Praveenkumar Karunakaran,9/25/2025, 10:57:08 AM,Qwen3-30B-A3B:latest,4096,127,0.4223,999.5777
+open-ui,9/19/2025, 2:21:37 PM,gpt-oss:20b,104,101,0.0205,90677.9531
+open-ui,9/19/2025, 1:52:14 PM,viewpoint-local,2381,316,0.0809,90677.9736
+Philipp A. Baer,9/19/2025, 1:20:58 PM,Qwen3-30B-A3B:latest,18,579,0.0597,42.0351
+Philipp A. Baer,9/19/2025, 1:20:17 PM,Qwen3-30B-A3B:latest,142,1047,0.1189,42.0948
+Philipp A. Baer,9/19/2025, 11:29:51 AM,Qwen3-30B-A3B:latest,1406,1021,0.2427,42.2137
+Philipp A. Baer,9/19/2025, 11:28:15 AM,Qwen3-30B-A3B:latest,24,1126,0.1150,42.4564
+Philipp A. Baer,9/18/2025, 12:37:50 PM,Qwen3-30B-A3B:latest,605,1084,0.1689,42.5714
+Philipp A. Baer,9/18/2025, 12:36:56 PM,Qwen3-30B-A3B:latest,23,565,0.0588,42.7403
+Philipp A. Baer,9/18/2025, 4:04:14 AM,Qwen3-30B-A3B:latest,4085,778,0.4863,42.7991
+Philipp A. Baer,9/18/2025, 4:03:40 AM,Qwen3-30B-A3B:latest,3114,948,0.4062,43.2854
+Philipp A. Baer,9/18/2025, 4:03:11 AM,Qwen3-30B-A3B:latest,2681,604,0.3285,43.6916
+Philipp A. Baer,9/18/2025, 3:42:49 AM,Qwen3-30B-A3B:latest,1434,1010,0.2444,44.0201
+Philipp A. Baer,9/18/2025, 3:42:21 AM,Qwen3-30B-A3B:latest,26,1388,0.1414,44.2645
+Philipp A. Baer,9/17/2025, 1:28:50 PM,Qwen3-30B-A3B:latest,3317,1190,0.4507,44.4059
+Philipp A. Baer,9/17/2025, 1:23:30 PM,Qwen3-30B-A3B:latest,2913,1354,0.4267,44.8566
+Philipp A. Baer,9/17/2025, 1:21:44 PM,Qwen3-30B-A3B:latest,2580,1574,0.4154,45.2833
+Philipp A. Baer,9/17/2025, 1:20:49 PM,Qwen3-30B-A3B:latest,3350,1194,0.4544,45.6987
+Philipp A. Baer,9/17/2025, 1:07:12 PM,Qwen3-30B-A3B:latest,2551,1326,0.3877,46.1531
+Philipp A. Baer,9/17/2025, 1:05:19 PM,Qwen3-30B-A3B:latest,33,1956,0.1989,46.5408
+Philipp A. Baer,9/17/2025, 12:59:01 PM,Qwen3-30B-A3B:latest,2689,904,0.3593,46.7397
+Philipp A. Baer,9/17/2025, 12:53:15 PM,Qwen3-30B-A3B:latest,2304,1211,0.3515,47.0990
+Philipp A. Baer,9/17/2025, 12:52:40 PM,Qwen3-30B-A3B:latest,22,1317,0.1339,47.4505
+Philipp A. Baer,9/17/2025, 10:23:24 AM,Qwen3-30B-A3B:latest,2500,1596,0.4096,47.5844
+Philipp A. Baer,9/17/2025, 10:20:35 AM,Qwen3-30B-A3B:latest,2902,1379,0.4281,47.9940
+Philipp A. Baer,9/17/2025, 10:16:59 AM,Qwen3-30B-A3B:latest,3278,931,0.4209,48.4221
+Philipp A. Baer,9/17/2025, 9:50:14 AM,Qwen3-30B-A3B:latest,2586,1866,0.4452,48.8430
+Philipp A. Baer,9/17/2025, 9:39:18 AM,Qwen3-30B-A3B:latest,1327,1226,0.2553,49.2882
+Philipp A. Baer,9/17/2025, 9:38:40 AM,Qwen3-30B-A3B:latest,19,1282,0.1301,49.5435
+Philipp A. Baer,9/17/2025, 4:23:14 AM,gpt-oss:20b,97,1020,0.1117,49.6736
+Philipp A. Baer,9/16/2025, 11:15:00 AM,Qwen3-30B-A3B:latest,16,283,0.0299,49.7853
+Philipp A. Baer,9/16/2025, 11:14:49 AM,gpt-oss:20b,100,485,0.0585,49.8152
+open-ui,9/4/2025, 2:39:05 PM,Qwen3-30B-A3B:latest,24,510,0.0534,90678.0545
+Martin Haunschild,8/6/2025, 9:50:39 AM,gpt-oss:20b,106,605,0.0711,999.9289
+Vishnu,8/6/2025, 8:06:42 AM,viewpoint-local,5139,603,0.1723,29.0951
+open-ui,8/4/2025, 6:52:25 PM,viewpoint-local,3684,545,0.1269,90678.1079
+open-ui,8/4/2025, 6:51:35 PM,viewpoint-local,3012,655,0.1100,90678.2348
+open-ui,8/4/2025, 6:50:36 PM,viewpoint-local,2491,502,0.0898,90678.3448
+open-ui,8/4/2025, 6:49:07 PM,viewpoint-local,1908,564,0.0742,90678.4346
+open-ui,8/4/2025, 6:44:38 PM,viewpoint-local,1266,626,0.0568,90678.5088
+open-ui,8/4/2025, 6:43:59 PM,viewpoint-local,835,415,0.0375,90678.5656
+open-ui,8/4/2025, 6:43:16 PM,viewpoint-local,448,375,0.0247,90678.6031
+open-ui,8/4/2025, 6:42:12 PM,viewpoint-local,187,236,0.0127,90678.6278
+open-ui,8/4/2025, 6:40:59 PM,viewpoint-local,4096,139,0.1271,90678.6405
+open-ui,8/4/2025, 4:20:46 PM,viewpoint-jira,7414,1451,0.3675,90678.7676
+open-ui,8/4/2025, 4:18:18 PM,Qwen3-30B-A3B:latest,419,755,0.1174,90679.1351
+open-ui,8/4/2025, 4:17:41 PM,Qwen3-30B-A3B:latest,42,334,0.0376,90679.2525
+open-ui,8/4/2025, 4:16:37 PM,Qwen3-30B-A3B:latest,42,366,0.0408,90679.2901
+open-ui,8/4/2025, 3:19:13 PM,Qwen3-8b:latest,59357,1356,3.1035,90679.3309
+open-ui,8/4/2025, 3:16:43 PM,Qwen3-8b:latest,25608,982,1.3786,90682.4344
+open-ui,8/4/2025, 3:06:16 PM,Qwen3-8b:latest,401,793,0.0994,90683.8130
+open-ui,7/30/2025, 1:23:26 PM,mistral-small-2506:latest,4096,608,0.4704,90683.9124
+open-ui,7/16/2025, 8:32:13 AM,viewpoint-jira,8079,1060,0.3484,90684.3828
+open-ui,7/16/2025, 8:22:16 AM,Qwen3-8b:latest,611,1477,0.1783,90684.7312
+open-ui,7/16/2025, 8:20:36 AM,Qwen3-8b:latest,420,287,0.0497,90684.9095
+open-ui,7/1/2025, 7:15:56 PM,Qwen3-8b:latest,17,126,0.0135,90684.9592
+open-ui,7/1/2025, 4:46:37 PM,qwen2.5-coder-extra-ctx:7b,194,161,0.0258,90684.9727
+Vishnu,7/1/2025, 8:53:42 AM,qwen2.5-coder-extra-ctx:7b,45,73,0.0096,29.2674
+Katarzyna Szajkowska,6/30/2025, 3:21:34 PM,viewpoint-jira,104,202,0.0233,999.9767
+open-ui,6/14/2025, 3:01:56 PM,qwen2.5-coder-extra-ctx:7b,400,161,0.0361,90684.9985
+open-ui,6/14/2025, 2:58:39 PM,Qwen3-8b:latest,14,340,0.0347,90685.0346
+Philipp A. Baer,6/6/2025, 6:32:26 AM,qwen2.5-coder-extra-ctx:7b,40,288,0.0308,49.8737
+open-ui,6/3/2025, 2:10:40 PM,qwen2.5-coder-extra-ctx:7b,548,98,0.0372,90685.0693
+open-ui,6/3/2025, 12:47:45 PM,qwen2.5-coder-extra-ctx:7b,433,47,0.0264,90685.1065
+open-ui,6/3/2025, 12:45:35 PM,mistral-small-3.1:custom,403,79,0.0640,90685.1329
+open-ui,6/3/2025, 12:05:46 PM,mistral-small-3.1:custom,437,59,0.0614,90685.1969
+open-ui,6/3/2025, 12:03:16 PM,qwen2.5-coder-extra-ctx:7b,465,65,0.0298,90685.2583
+open-ui,6/3/2025, 11:54:56 AM,qwen2.5-coder-extra-ctx:7b,527,73,0.0337,90685.2881
+open-ui,6/3/2025, 11:53:55 AM,qwen2.5-coder-extra-ctx:7b,515,67,0.0325,90685.3218
+open-ui,6/3/2025, 11:52:13 AM,qwen2.5-coder-extra-ctx:7b,439,73,0.0293,90685.3543
+open-ui,6/3/2025, 11:50:39 AM,qwen2.5-coder-extra-ctx:7b,464,71,0.0303,90685.3836
+open-ui,6/3/2025, 11:49:21 AM,qwen2.5-coder-extra-ctx:7b,441,84,0.0304,90685.4139
+open-ui,6/3/2025, 11:47:21 AM,qwen2.5-coder-extra-ctx:7b,438,47,0.0266,90685.4443
+open-ui,6/3/2025, 8:00:56 AM,mistral-small-3.1:custom,6539,111,0.6872,90685.4709
+open-ui,6/3/2025, 8:00:51 AM,mistral-small-3.1:custom,34,558,0.1708,90686.1581
+open-ui,6/3/2025, 7:57:55 AM,mistral-small-3.1:custom,14,0,0.0000,90686.3289
+open-ui,6/2/2025, 8:55:25 AM,mistral-small-3.1:custom,403,80,0.0643,90686.3289
+open-ui,6/2/2025, 8:40:27 AM,mistral-small-3.1:custom,9,385,0.1164,90686.3932
+open-ui,5/30/2025, 9:57:22 AM,qwen2.5-coder-extra-ctx:7b,18434,320,0.9537,90686.5096
+open-ui,5/30/2025, 9:56:31 AM,qwen2.5-coder-extra-ctx:7b,36,117,0.0135,90687.4633
+open-ui,5/30/2025, 9:56:15 AM,qwen2.5-coder-extra-ctx:7b,43,318,0.0339,90687.4768
+open-ui,5/30/2025, 9:54:52 AM,qwen2.5-coder-extra-ctx:7b,43,253,0.0275,90687.5107
+Vishnu,5/30/2025, 7:06:06 AM,qwen2.5-coder-extra-ctx:7b,349,27,0.0202,29.2770
+Vishnu,5/30/2025, 7:05:46 AM,qwen2.5-coder-extra-ctx:7b,351,34,0.0210,29.2972
+Vishnu,5/30/2025, 7:05:24 AM,qwen2.5-coder-extra-ctx:7b,348,19,0.0193,29.3182
+Vishnu,5/30/2025, 7:04:36 AM,qwen2.5-coder-extra-ctx:7b,345,15,0.0188,29.3375
+Vishnu,5/30/2025, 7:01:30 AM,qwen2.5-coder-extra-ctx:7b,324,98,0.0260,29.3563
+Vishnu,5/30/2025, 6:49:51 AM,qwen2.5-coder-extra-ctx:7b,334,79,0.0246,29.3823
+Vishnu,5/30/2025, 6:46:52 AM,qwen2.5-coder-extra-ctx:7b,330,107,0.0272,29.4069
+Vishnu,5/30/2025, 6:28:36 AM,qwen2.5-coder-extra-ctx:7b,330,109,0.0439,29.4341
+Vishnu,5/30/2025, 6:27:47 AM,qwen2.5-coder-extra-ctx:7b,346,274,0.0620,29.4780
+Vishnu,5/30/2025, 6:26:35 AM,qwen2.5-coder-extra-ctx:7b,339,77,0.0416,29.5400
+Vishnu,5/30/2025, 6:26:04 AM,qwen2.5-coder-extra-ctx:7b,322,72,0.0394,29.5816
+Vishnu,5/30/2025, 6:23:03 AM,qwen2.5-coder-extra-ctx:7b,54,253,0.0307,29.6210
+open-ui,5/30/2025, 6:20:56 AM,qwen2.5-coder-extra-ctx:7b,561,42,0.0603,90687.5382
+open-ui,5/30/2025, 6:20:09 AM,qwen2.5-coder-extra-ctx:7b,1240,64,0.1304,90687.5985
+open-ui,5/28/2025, 2:52:21 PM,qwen2.5-coder-extra-ctx:7b,419,243,0.0662,90687.7289
+open-ui,5/28/2025, 2:39:37 PM,qwen2.5-coder-extra-ctx:7b,423,101,0.0524,90687.7951
+open-ui,5/28/2025, 2:36:13 PM,qwen2.5-coder-extra-ctx:7b,454,68,0.0522,90687.8475
+open-ui,5/28/2025, 1:58:19 PM,qwen2.5-coder-extra-ctx:7b,44,175,0.0219,90687.8997
+open-ui,5/28/2025, 1:58:00 PM,qwen2.5-coder-extra-ctx:7b,440,48,0.0488,90687.9216
+open-ui,5/28/2025, 1:55:36 PM,Qwen3-8b:latest,19,707,0.0726,90687.9704
+open-ui,5/28/2025, 1:53:23 PM,qwen2.5-coder-extra-ctx:7b,36,152,0.0188,90688.0430
+open-ui,5/28/2025, 1:44:49 PM,qwen2.5-coder-extra-ctx:7b,43,246,0.0289,90688.0618
+open-ui,5/28/2025, 1:27:49 PM,qwen2.5-coder-extra-ctx:7b,461,87,0.0548,90688.0907
+open-ui,5/28/2025, 1:27:11 PM,qwen2.5-coder-extra-ctx:7b,446,41,0.0487,90688.1455
+open-ui,5/28/2025, 1:24:21 PM,qwen2.5-coder-extra-ctx:7b,511,56,0.0567,90688.1942
+open-ui,5/28/2025, 1:21:09 PM,qwen2.5-coder-extra-ctx:7b,381,73,0.0454,90688.2509
+open-ui,5/28/2025, 1:19:57 PM,qwen2.5-coder-extra-ctx:7b,402,63,0.0465,90688.2963
+open-ui,5/28/2025, 7:25:43 AM,qwen2.5-coder-extra-ctx:7b,613,55,0.0668,90688.3428
+open-ui,5/27/2025, 2:05:28 PM,qwen2.5-coder-extra-ctx:7b,361,57,0.0418,90688.4096
+Ashok Sankaranarayanan,5/27/2025, 1:39:51 PM,qwen2.5-coder-extra-ctx:7b,6134,40,0.6174,99391.0706
+Ashok Sankaranarayanan,5/27/2025, 1:39:03 PM,qwen2.5-coder-extra-ctx:7b,38,82,0.0120,99391.6880
+Ashok Sankaranarayanan,5/27/2025, 1:38:04 PM,tool-validation,6036,47,608.3000,99391.7000
+Ashok Sankaranarayanan,5/27/2025, 1:18:06 PM,tool-validation,4096,134,423.0000,-385.5074
+Ashok Sankaranarayanan,5/27/2025, 1:17:05 PM,tool-validation,71,48,11.9000,37.4926
+Ashok Sankaranarayanan,5/27/2025, 1:16:09 PM,qwen2.5-coder-extra-ctx:7b,6028,46,0.6074,49.3926
+open-ui,5/27/2025, 11:27:19 AM,viewpoint-jira,6751,527,727.8000,90688.4514
+open-ui,5/27/2025, 11:26:28 AM,viewpoint-jira,81,66,14.7000,91416.2514
+Philipp A. Baer,5/27/2025, 11:20:23 AM,qwen2.5-coder-extra-ctx:7b,393,81,0.0474,49.9045
+Philipp A. Baer,5/27/2025, 11:19:11 AM,qwen2.5-coder-extra-ctx:7b,297,78,0.0375,49.9519
+Philipp A. Baer,5/27/2025, 11:18:48 AM,qwen2.5-coder-extra-ctx:7b,38,68,0.0106,49.9894
+open-ui,5/27/2025, 11:05:06 AM,qwen2.5-coder-extra-ctx:7b,416,55,0.0471,91430.9514
+open-ui,5/27/2025, 11:04:13 AM,qwen2.5-coder-extra-ctx:7b,420,59,0.0479,91430.9985
+open-ui,5/27/2025, 11:03:28 AM,qwen2.5-coder-extra-ctx:7b,221,54,0.0275,91431.0464
+open-ui,5/27/2025, 11:03:28 AM,qwen2.5-coder-extra-ctx:7b,221,41,0.0262,91431.0739
+open-ui,5/27/2025, 11:01:07 AM,qwen2.5-coder-extra-ctx:7b,221,460,0.0681,91431.1001
+Vishnu,5/27/2025, 9:16:09 AM,qwen2.5-coder-extra-ctx:7b,405,149,0.0554,29.6517
+Vishnu,5/27/2025, 9:09:30 AM,viewpoint-jira,88,54,14.2000,29.7071
+Vishnu,5/27/2025, 9:09:16 AM,qwen2.5-coder-extra-ctx:7b,30,43,0.0073,43.9071
+open-ui,5/22/2025, 1:54:06 PM,viewpoint-jira,967,242,120.9000,91431.1682
+open-ui,5/22/2025, 1:53:43 PM,viewpoint-jira,749,176,92.5000,91552.0682
+open-ui,5/22/2025, 1:53:17 PM,viewpoint-jira,1759,111,187.0000,91644.5682
+open-ui,5/22/2025, 1:52:54 PM,viewpoint-jira,7955,147,810.2000,91831.5682
+open-ui,5/22/2025, 1:50:59 PM,viewpoint-jira,733,93,82.6000,92641.7682
+open-ui,5/22/2025, 1:45:04 PM,viewpoint-jira,1047,95,114.2000,92724.3682
+open-ui,5/22/2025, 1:42:09 PM,viewpoint-jira,1047,96,114.3000,92838.5682
+open-ui,5/22/2025, 1:38:04 PM,viewpoint-jira,1036,85,112.1000,92952.8682
+open-ui,5/22/2025, 1:35:44 PM,viewpoint-jira,10667,144,1081.1000,93064.9682
+open-ui,5/22/2025, 1:35:02 PM,viewpoint-jira,10551,122,1067.3000,94146.0682
+open-ui,5/22/2025, 11:47:23 AM,viewpoint-jira,908,81,98.9000,95213.3682
+open-ui,5/22/2025, 11:46:54 AM,viewpoint-jira,10572,126,1069.8000,95312.2682
+open-ui,5/22/2025, 11:45:47 AM,viewpoint-jira,10693,105,1079.8000,96382.0682
+open-ui,5/22/2025, 11:44:12 AM,viewpoint-jira,10676,87,1076.3000,97461.8682
+open-ui,5/22/2025, 11:43:39 AM,viewpoint-jira,725,102,82.7000,98538.1682
+open-ui,5/22/2025, 11:43:05 AM,viewpoint-jira,735,131,86.6000,98620.8682
+open-ui,5/22/2025, 11:42:31 AM,viewpoint-jira,10539,123,1066.2000,98707.4682
+open-ui,5/22/2025, 11:41:58 AM,viewpoint-jira,721,125,84.6000,99773.6682
+open-ui,5/22/2025, 11:39:18 AM,viewpoint-jira,572,76,64.8000,99858.2682
+open-ui,5/22/2025, 11:38:39 AM,viewpoint-jira,451,109,56.0000,99923.0682
+open-ui,5/22/2025, 11:35:36 AM,qwen2.5-coder-extra-ctx:7b,1587,222,0.1809,99979.0682
+open-ui,5/21/2025, 3:18:54 PM,qwen2.5-coder-extra-ctx:7b,1567,240,0.1807,99979.2491
+open-ui,5/21/2025, 3:17:09 PM,qwen2.5-coder-extra-ctx:7b,1562,120,0.1682,99979.4298
+open-ui,5/21/2025, 3:15:40 PM,qwen2.5-coder-extra-ctx:7b,1569,120,0.1689,99979.5980
+open-ui,5/21/2025, 3:13:09 PM,qwen2.5-coder-extra-ctx:7b,1562,81,0.1643,99979.7669
+open-ui,5/21/2025, 3:12:12 PM,qwen2.5-coder-extra-ctx:7b,1242,222,0.1464,99979.9312
+open-ui,5/21/2025, 3:10:15 PM,qwen2.5-coder-extra-ctx:7b,1694,57,0.1751,99980.0776
+open-ui,5/21/2025, 8:02:11 AM,qwen2.5-coder-extra-ctx:7b,1328,71,0.1399,99980.2527
+open-ui,5/21/2025, 7:51:53 AM,qwen2.5-coder-extra-ctx:7b,1314,52,0.1366,99980.3926
+open-ui,5/21/2025, 7:45:27 AM,qwen2.5-coder-extra-ctx:7b,1678,56,0.1734,99980.5292
+open-ui,5/21/2025, 7:44:21 AM,qwen2.5-coder-extra-ctx:7b,1677,225,0.1902,99980.7026
+Vishnu,5/21/2025, 7:39:49 AM,qwen2.5-coder-extra-ctx:7b,36,76,0.0112,43.9144
+Vishnu,5/20/2025, 11:31:42 AM,viewpoint-jira,30,30,6.0000,43.9256
+open-ui,5/13/2025, 1:31:36 PM,qwen2.5-coder-extra-ctx:7b,789,201,0.0990,99980.8928
+open-ui,5/12/2025, 2:18:19 PM,qwen2.5-coder-extra-ctx:7b,1391,84,0.1475,99980.9918
+open-ui,5/12/2025, 2:16:03 PM,qwen2.5-coder-extra-ctx:7b,1150,86,0.1236,99981.1393
+open-ui,5/12/2025, 1:56:07 PM,qwen2.5-coder-extra-ctx:7b,1150,86,0.1236,99981.2629
+open-ui,5/12/2025, 1:46:35 PM,qwen2.5-coder-extra-ctx:7b,1150,86,0.1236,99981.3865
+open-ui,5/12/2025, 1:44:35 PM,qwen2.5-coder-extra-ctx:7b,908,86,0.0994,99981.5101
+open-ui,5/12/2025, 1:24:18 PM,qwen2.5-coder-extra-ctx:7b,908,86,0.0994,99981.6095
+open-ui,5/12/2025, 9:52:34 AM,qwen2.5-coder-extra-ctx:7b,666,86,0.0752,99981.7089
+open-ui,5/2/2025, 9:41:06 AM,qwen2.5-coder-extra-ctx:7b,695,54,0.0749,99981.7841
+open-ui,5/2/2025, 9:39:51 AM,qwen2.5-coder-extra-ctx:7b,874,32,0.0906,99981.8590
+open-ui,5/2/2025, 9:36:01 AM,qwen2.5-coder-extra-ctx:7b,681,271,0.0952,99981.9496
+open-ui,4/23/2025, 3:11:23 PM,qwen2.5-coder-extra-ctx:7b,681,185,0.0866,99982.0448
+open-ui,4/23/2025, 3:08:59 PM,qwen2.5-coder-extra-ctx:7b,707,104,0.0811,99982.1314
+open-ui,4/23/2025, 2:58:13 PM,qwen2.5-coder-extra-ctx:7b,728,60,0.0788,99982.2125
+open-ui,4/23/2025, 2:55:48 PM,qwen2.5-coder-extra-ctx:7b,388,40,0.0428,99982.2913
+open-ui,4/16/2025, 3:31:42 PM,qwen2.5-coder-extra-ctx:7b,952,86,0.1038,99982.3341
+open-ui,4/16/2025, 3:18:48 PM,qwen2.5-coder-extra-ctx:7b,181,402,0.0583,99982.4379
+open-ui,4/16/2025, 1:38:17 PM,llama3.2:latest,179,573,0.0226,99982.4962
+open-ui,4/16/2025, 1:24:21 PM,qwen2.5-coder-extra-ctx:7b,451,95,0.0546,99982.5188
+open-ui,4/16/2025, 1:14:57 PM,qwen2.5-coder-extra-ctx:7b,718,84,0.0802,99982.5734
+open-ui,4/15/2025, 12:40:08 PM,qwen2.5-coder-extra-ctx:7b,425,48,0.0473,99982.6536
+open-ui,4/15/2025, 9:50:22 AM,qwen2.5-coder-extra-ctx:7b,449,60,0.0509,99982.7009
+open-ui,4/15/2025, 9:48:47 AM,qwen2.5-coder-extra-ctx:7b,436,57,0.0493,99982.7518
+open-ui,4/15/2025, 9:08:16 AM,qwen2.5-coder-extra-ctx:7b,1323,51,0.1374,99982.8011
+open-ui,4/15/2025, 9:06:59 AM,qwen2.5-coder-extra-ctx:7b,1345,222,0.1567,99982.9385
+open-ui,4/15/2025, 9:05:11 AM,qwen2.5-coder-extra-ctx:7b,45,486,0.0531,99983.0952
+open-ui,4/15/2025, 9:03:20 AM,qwen2.5-coder-extra-ctx:7b,48,64,0.0112,99983.1483
+open-ui,4/15/2025, 8:59:25 AM,qwen2.5-coder-extra-ctx:7b,1110,248,0.1358,99983.1595
+open-ui,4/15/2025, 8:58:57 AM,qwen2.5-coder-extra-ctx:7b,1096,152,0.1248,99983.2953
+open-ui,4/15/2025, 8:58:06 AM,qwen2.5-coder-extra-ctx:7b,1030,208,0.1238,99983.4201
+open-ui,4/15/2025, 8:57:36 AM,qwen2.5-coder-extra-ctx:7b,1038,154,0.1192,99983.5439
+open-ui,4/15/2025, 8:56:15 AM,qwen2.5-coder-extra-ctx:7b,520,214,0.0734,99983.6631
+open-ui,4/8/2025, 12:09:05 PM,qwen2.5-coder-extra-ctx:7b,8183,420,0.8603,99983.7365
+open-ui,4/8/2025, 12:08:15 PM,qwen2.5-coder-extra-ctx:7b,8800,96,0.8896,99984.5968
+open-ui,4/8/2025, 12:07:31 PM,qwen2.5-coder-extra-ctx:7b,4739,154,0.4893,99985.4864
+open-ui,4/8/2025, 12:06:15 PM,qwen2.5-coder-extra-ctx:7b,8696,510,0.9206,99985.9757
+open-ui,4/8/2025, 12:05:10 PM,qwen2.5-coder-extra-ctx:7b,8703,44,0.8747,99986.8963
+open-ui,4/8/2025, 9:02:51 AM,qwen2.5-coder-extra-ctx:7b,522,112,0.0634,99987.7710
+open-ui,4/8/2025, 9:01:59 AM,qwen2.5-coder-extra-ctx:7b,605,73,0.0678,99987.8344
+open-ui,4/8/2025, 9:00:37 AM,qwen2.5-coder-extra-ctx:7b,537,59,0.0596,99987.9022
+open-ui,4/8/2025, 9:00:18 AM,qwen2.5-coder-extra-ctx:7b,537,106,0.0643,99987.9618
+open-ui,4/8/2025, 8:59:01 AM,qwen2.5-coder-extra-ctx:7b,537,127,0.0664,99988.0261
+open-ui,4/8/2025, 8:51:03 AM,qwen2.5-coder-extra-ctx:7b,663,66,0.0729,99988.0925
+open-ui,4/4/2025, 8:56:23 AM,qwen2.5-coder-extra-ctx:7b,904,171,0.1075,99988.1654
+open-ui,4/4/2025, 8:56:04 AM,llama3.2:latest,380,341,0.0216,99988.2729
+open-ui,4/4/2025, 8:55:34 AM,qwen2.5-coder-extra-ctx:7b,779,102,0.0881,99988.2945
+open-ui,4/4/2025, 8:52:11 AM,qwen2.5-coder-extra-ctx:7b,548,167,0.0715,99988.3826
+open-ui,4/3/2025, 3:03:17 PM,qwen2.5-coder-extra-ctx:7b,673,157,0.0830,99988.4541
+open-ui,4/3/2025, 3:02:49 PM,qwen2.5-coder-extra-ctx:7b,449,127,0.0576,99988.5371
+open-ui,4/3/2025, 3:02:29 PM,llama3.2:latest,36,316,0.0106,99988.5947
+open-ui,4/3/2025, 3:02:03 PM,llama3.2:latest,48,316,0.0109,99988.6053
+open-ui,4/3/2025, 3:01:13 PM,llama3.2:latest,35,126,0.0048,99988.6162
+open-ui,4/3/2025, 3:00:27 PM,llama3.2:latest,33,112,0.0044,99988.6210
+open-ui,4/3/2025, 9:46:24 AM,llama3.2:latest,277,363,0.0192,99988.6254
+open-ui,4/3/2025, 9:38:27 AM,llama3.2:latest,654,99,0.0226,99988.6446
+open-ui,4/3/2025, 9:35:02 AM,llama3.2:latest,439,100,0.0162,99988.6672
+open-ui,4/3/2025, 9:34:41 AM,llama3.2:latest,431,67,0.0149,99988.6834
+open-ui,4/3/2025, 9:34:06 AM,qwen2.5-coder-extra-ctx:7b,2621,1,0.2622,99988.6983
+open-ui,4/3/2025, 9:32:11 AM,qwen2.5-coder-extra-ctx:7b,2068,1,0.2069,99988.9605
+open-ui,4/3/2025, 9:31:19 AM,qwen2.5-coder-extra-ctx:7b,2078,1,0.2079,99989.1674
+open-ui,4/3/2025, 9:29:49 AM,qwen2.5-coder-extra-ctx:7b,1370,310,0.1680,99989.3753
+open-ui,4/3/2025, 9:29:22 AM,qwen2.5-coder-extra-ctx:7b,484,139,0.0623,99989.5433
+open-ui,4/3/2025, 9:26:16 AM,qwen2.5-coder-extra-ctx:7b,421,145,0.0566,99989.6056
+open-ui,4/3/2025, 9:23:25 AM,qwen2.5-coder-extra-ctx:7b,468,143,0.0611,99989.6622
+open-ui,4/3/2025, 9:22:50 AM,qwen2.5-coder-extra-ctx:7b,458,86,0.0544,99989.7233
+open-ui,4/3/2025, 9:22:42 AM,qwen2.5-coder-extra-ctx:7b,458,83,0.0541,99989.7777
+open-ui,4/3/2025, 9:21:08 AM,qwen2.5-coder-extra-ctx:7b,434,36,0.0470,99989.8318
+open-ui,4/3/2025, 9:17:59 AM,qwen2.5-coder-extra-ctx:7b,538,187,0.0725,99989.8788
+open-ui,4/3/2025, 9:16:43 AM,qwen2.5-coder-extra-ctx:7b,427,77,0.0504,99989.9513
+open-ui,4/3/2025, 9:14:03 AM,qwen2.5-coder-extra-ctx:7b,36,33,0.0069,99990.0017
+open-ui,4/3/2025, 9:03:52 AM,qwen2.5-coder-extra-ctx:7b,36,107,0.0143,99990.0086
+open-ui,4/3/2025, 8:27:30 AM,qwen2.5-coder-extra-ctx:7b,38,95,0.0133,99990.0229
+open-ui,3/31/2025, 2:11:00 PM,qwen2.5-coder-extra-ctx:7b,40,123,0.0163,99990.0362
+open-ui,3/31/2025, 2:07:40 PM,qwen2.5-coder-extra-ctx:7b,402,56,0.0458,99990.0525
+open-ui,3/31/2025, 2:06:37 PM,qwen2.5-coder-extra-ctx:7b,43,198,0.0241,99990.0983
+open-ui,3/31/2025, 2:06:13 PM,qwen2.5-coder-extra-ctx:7b,37,67,0.0104,99990.1224
+open-ui,3/31/2025, 2:02:05 PM,qwen2.5-coder-extra-ctx:7b,396,13,0.0409,99990.1328
+open-ui,3/31/2025, 2:01:59 PM,qwen2.5-coder-extra-ctx:7b,37,98,0.0135,99990.1737
+open-ui,3/31/2025, 2:00:16 PM,qwen2.5-coder-extra-ctx:7b,396,286,0.0682,99990.1872
+open-ui,3/31/2025, 1:59:34 PM,qwen2.5-coder-extra-ctx:7b,401,54,0.0455,99990.2554
+open-ui,3/31/2025, 1:57:52 PM,qwen2.5-coder-extra-ctx:7b,494,34,0.0528,99990.3009
+open-ui,3/31/2025, 1:55:02 PM,qwen2.5-coder-extra-ctx:7b,1289,248,0.1537,99990.3537
+open-ui,3/31/2025, 1:54:40 PM,qwen2.5-coder-extra-ctx:7b,467,70,0.0537,99990.5074
+open-ui,3/31/2025, 1:47:21 PM,qwen2.5-coder-extra-ctx:7b,708,388,0.1096,99990.5611
+open-ui,3/31/2025, 1:45:20 PM,qwen2.5-coder-extra-ctx:7b,672,48,0.0720,99990.6707
+open-ui,3/31/2025, 1:44:38 PM,qwen2.5-coder-extra-ctx:7b,566,103,0.0669,99990.7427
+open-ui,3/31/2025, 1:43:45 PM,qwen2.5-coder-extra-ctx:7b,463,61,0.0524,99990.8096
+open-ui,3/31/2025, 1:40:40 PM,qwen2.5-coder-extra-ctx:7b,482,77,0.0559,99990.8620
+open-ui,3/31/2025, 1:40:17 PM,qwen2.5-coder-extra-ctx:7b,462,61,0.0523,99990.9179
+open-ui,3/31/2025, 1:39:56 PM,qwen2.5-coder-extra-ctx:7b,471,63,0.0534,99990.9702
+open-ui,3/31/2025, 1:34:03 PM,qwen2.5-coder-extra-ctx:7b,1913,1,0.1914,99991.0236
+open-ui,3/31/2025, 1:33:32 PM,qwen2.5-coder-extra-ctx:7b,614,309,0.0923,99991.2150
+open-ui,3/31/2025, 1:30:44 PM,qwen2.5-coder-extra-ctx:7b,462,115,0.0577,99991.3073
+open-ui,3/31/2025, 10:21:42 AM,qwen2.5-coder-extra-ctx:7b,453,97,0.0550,99991.3650
+open-ui,3/31/2025, 10:17:29 AM,qwen2.5-coder-extra-ctx:7b,453,73,0.0526,99991.4200
+open-ui,3/31/2025, 10:16:35 AM,qwen2.5-coder-extra-ctx:7b,448,45,0.0493,99991.4726
+open-ui,3/31/2025, 10:16:24 AM,qwen2.5-coder-extra-ctx:7b,448,54,0.0502,99991.5219
+open-ui,3/31/2025, 10:10:40 AM,qwen2.5-coder-extra-ctx:7b,456,156,0.0612,99991.5721
+open-ui,3/31/2025, 10:09:49 AM,qwen2.5-coder-extra-ctx:7b,407,115,0.0522,99991.6333
+open-ui,3/31/2025, 10:09:42 AM,qwen2.5-coder-extra-ctx:7b,407,14,0.0421,99991.6855
+open-ui,3/31/2025, 9:53:49 AM,qwen2.5-coder-extra-ctx:7b,405,35,0.0440,99991.7276
+open-ui,3/31/2025, 9:52:33 AM,qwen2.5-coder-extra-ctx:7b,405,47,0.0452,99991.7716
+open-ui,3/31/2025, 9:44:50 AM,qwen2.5-coder-extra-ctx:7b,447,121,0.0568,99991.8168
+open-ui,3/31/2025, 9:15:39 AM,qwen2.5-coder-extra-ctx:7b,458,52,0.0510,99991.8736
+open-ui,3/31/2025, 9:14:51 AM,qwen2.5-coder-extra-ctx:7b,449,53,0.0502,99991.9246
+open-ui,3/31/2025, 9:14:07 AM,qwen2.5-coder-extra-ctx:7b,443,54,0.0497,99991.9748
+open-ui,3/31/2025, 9:13:23 AM,qwen2.5-coder-extra-ctx:7b,408,69,0.0477,99992.0245
+open-ui,3/31/2025, 9:10:18 AM,qwen2.5-coder-extra-ctx:7b,447,48,0.0495,99992.0722
+open-ui,3/31/2025, 9:04:16 AM,qwen2.5-coder-extra-ctx:7b,436,82,0.0518,99992.1217
+open-ui,3/31/2025, 9:04:05 AM,qwen2.5-coder-extra-ctx:7b,37,64,0.0101,99992.1735
+open-ui,3/31/2025, 8:58:43 AM,qwen2.5-coder-extra-ctx:7b,473,46,0.0519,99992.1836
+open-ui,3/28/2025, 10:43:37 AM,viewpoint-local,2048,351,0.0720,99992.2355
+open-ui,3/28/2025, 10:43:07 AM,viewpoint-local,31,417,0.0134,99992.3075
+open-ui,3/27/2025, 5:30:56 PM,qwen2.5-coder-extra-ctx:7b,40,67,0.0107,99992.3209
+open-ui,3/27/2025, 5:24:36 PM,qwen2.5-coder-extra-ctx:7b,76,127,0.0203,99992.3316
+open-ui,3/27/2025, 5:19:27 PM,qwen2.5-coder-extra-ctx:7b,76,161,0.0237,99992.3519
+open-ui,3/27/2025, 5:17:44 PM,qwen2.5-coder-extra-ctx:7b,76,114,0.0190,99992.3756
+open-ui,3/27/2025, 5:17:06 PM,qwen2.5-coder-extra-ctx:7b,34,26,0.0060,99992.3946
+open-ui,3/27/2025, 5:16:12 PM,qwen2.5-coder-extra-ctx:7b,274,76,0.0350,99992.4006
+open-ui,3/27/2025, 5:10:40 PM,qwen2.5-coder-extra-ctx:7b,237,21,0.0258,99992.4356
+open-ui,3/27/2025, 5:09:34 PM,qwen2.5-coder-extra-ctx:7b,35,186,0.0221,99992.4614
+open-ui,3/27/2025, 5:09:25 PM,qwen2.5-coder-extra-ctx:7b,35,301,0.0336,99992.4835
+open-ui,3/27/2025, 5:09:09 PM,qwen2.5-coder-extra-ctx:7b,35,151,0.0186,99992.5171
+open-ui,3/27/2025, 5:06:15 PM,qwen2.5-coder-extra-ctx:7b,35,169,0.0204,99992.5357
+open-ui,3/27/2025, 5:04:26 PM,qwen2.5-coder-extra-ctx:7b,505,196,0.0701,99992.5561
+open-ui,3/27/2025, 5:04:02 PM,qwen2.5-coder-extra-ctx:7b,473,62,0.0535,99992.6262
+open-ui,3/27/2025, 5:03:17 PM,qwen2.5-coder-extra-ctx:7b,476,107,0.0583,99992.6797
+open-ui,3/27/2025, 5:03:05 PM,llama3.2:latest,30,546,0.0173,99992.7380
+Chiranjib,3/27/2025, 3:13:36 PM,qwen2.5-coder-extra-ctx:7b,1919,644,0.2563,49.3358
+Chiranjib,3/27/2025, 2:41:41 PM,qwen2.5-coder-extra-ctx:7b,1683,722,0.2405,49.5921
+open-ui,3/27/2025, 2:31:45 PM,qwen2.5-coder-extra-ctx:7b,569,52,0.0621,99992.7553
+Chiranjib,3/27/2025, 2:29:17 PM,qwen2.5-coder-extra-ctx:7b,459,659,0.1118,49.8326
+Chiranjib,3/27/2025, 2:25:44 PM,qwen2.5-coder-extra-ctx:7b,159,259,0.0418,49.9444
+Chiranjib,3/27/2025, 2:24:39 PM,qwen2.5-coder-extra-ctx:7b,77,61,0.0138,49.9862
+open-ui,3/27/2025, 11:30:14 AM,qwen2.5-coder-extra-ctx:7b,39,77,0.0116,99992.8174
+open-ui,3/25/2025, 3:31:21 PM,qwen2.5-coder-extra-ctx:7b,1265,159,0.1424,99992.8290
+open-ui,3/25/2025, 3:30:43 PM,qwen2.5-coder-extra-ctx:7b,1257,34,0.1291,99992.9714
+open-ui,3/25/2025, 3:30:16 PM,qwen2.5-coder-extra-ctx:7b,1242,56,0.1298,99993.1005
+open-ui,3/25/2025, 3:29:02 PM,qwen2.5-coder-extra-ctx:7b,1537,239,0.1776,99993.2303
+open-ui,3/25/2025, 3:28:30 PM,qwen2.5-coder-extra-ctx:7b,1236,283,0.1519,99993.4079
+open-ui,3/25/2025, 3:27:32 PM,qwen2.5-coder-extra-ctx:7b,1054,169,0.1223,99993.5598
+open-ui,3/25/2025, 3:26:59 PM,qwen2.5-coder-extra-ctx:7b,1058,66,0.1124,99993.6821
+open-ui,3/25/2025, 3:25:29 PM,qwen2.5-coder-extra-ctx:7b,1008,39,0.1047,99993.7945
+open-ui,3/25/2025, 3:23:32 PM,qwen2.5-coder-extra-ctx:7b,934,299,0.1233,99993.8992
+open-ui,3/25/2025, 3:22:05 PM,qwen2.5-coder-extra-ctx:7b,250,675,0.0925,99994.0225
+open-ui,3/25/2025, 3:20:39 PM,qwen2.5-coder-extra-ctx:7b,250,11,0.0261,99994.1150
+open-ui,3/25/2025, 3:19:37 PM,qwen2.5-coder-extra-ctx:7b,250,0,0.0000,99994.1411
+open-ui,3/25/2025, 3:19:12 PM,qwen2.5-coder-extra-ctx:7b,246,24,0.0270,99994.1411
+open-ui,3/25/2025, 3:18:22 PM,qwen2.5-coder-extra-ctx:7b,194,32,0.0226,99994.1681
+open-ui,3/25/2025, 3:17:25 PM,qwen2.5-coder-extra-ctx:7b,212,77,0.0289,99994.1907
+open-ui,3/25/2025, 3:16:44 PM,qwen2.5-coder-extra-ctx:7b,196,48,0.0244,99994.2196
+open-ui,3/25/2025, 3:16:02 PM,qwen2.5-coder-extra-ctx:7b,207,42,0.0249,99994.2440
+open-ui,3/25/2025, 3:14:33 PM,qwen2.5-coder-extra-ctx:7b,157,15,0.0172,99994.2689
+open-ui,3/25/2025, 3:14:08 PM,qwen2.5-coder-extra-ctx:7b,150,28,0.0178,99994.2861
+open-ui,3/25/2025, 3:13:28 PM,qwen2.5-coder-extra-ctx:7b,111,35,0.0146,99994.3039
+open-ui,3/25/2025, 2:59:56 PM,qwen2.5-coder-extra-ctx:7b,87,18,0.0105,99994.3185
+open-ui,3/25/2025, 2:59:34 PM,qwen2.5-coder-extra-ctx:7b,44,37,0.0081,99994.3290
+open-ui,3/25/2025, 2:58:52 PM,qwen2.5-coder-extra-ctx:7b,7,20,0.0027,99994.3371
+Philipp A. Baer,3/25/2025, 2:00:50 PM,hf.co/bartowski/open-r1_OlympicCoder-7B-GGUF:Q4_K_M,44,369,41.3000,-3.6517
+open-ui,3/25/2025, 1:57:17 PM,qwen2.5-coder-extra-ctx:7b,1452,43,0.1495,99994.3398
+open-ui,3/25/2025, 1:56:53 PM,qwen2.5-coder-extra-ctx:7b,1400,32,0.1432,99994.4893
+open-ui,3/25/2025, 1:55:21 PM,qwen2.5-coder-extra-ctx:7b,691,231,0.0922,99994.6325
+open-ui,3/25/2025, 1:53:37 PM,qwen2.5-coder-extra-ctx:7b,547,136,0.0683,99994.7247
+open-ui,3/25/2025, 1:47:52 PM,qwen2.5-coder-extra-ctx:7b,381,160,0.0541,99994.7930
+open-ui,3/25/2025, 1:45:26 PM,qwen2.5-coder-extra-ctx:7b,385,0,0.0000,99994.8471
+open-ui,3/25/2025, 1:44:18 PM,qwen2.5-coder-extra-ctx:7b,259,108,0.0367,99994.8471
+open-ui,3/25/2025, 1:35:41 PM,qwen2.5-coder-extra-ctx:7b,223,28,0.0251,99994.8838
+open-ui,3/25/2025, 1:34:20 PM,qwen2.5-coder-extra-ctx:7b,78,140,0.0218,99994.9089
+open-ui,3/25/2025, 1:30:40 PM,qwen2.5-coder-extra-ctx:7b,83,0,0.0000,99994.9307
+open-ui,3/25/2025, 1:22:23 PM,qwen2.5-coder-extra-ctx:7b,441,66,0.0507,99994.9307
+open-ui,3/24/2025, 3:22:08 PM,qwen2.5-coder-extra-ctx:7b,5,38,0.0043,99994.9814
+open-ui,3/24/2025, 3:16:36 PM,qwen2.5-coder-extra-ctx:7b,6,183,0.0189,99994.9857
+open-ui,3/24/2025, 3:13:34 PM,hf.co/bartowski/DeepSeek-R1-Distill-Qwen-7B-GGUF:Q4_K_M,6,0,0.0000,99995.0046
+open-ui,3/24/2025, 3:12:02 PM,hf.co/bartowski/DeepSeek-R1-Distill-Qwen-7B-GGUF:Q4_K_M,6,0,0.0000,99995.0046
+open-ui,3/24/2025, 3:10:06 PM,llama3.2:latest,6,134,0.0042,99995.0046
+open-ui,3/24/2025, 3:05:35 PM,llama3.2:latest,31,53,0.0025,99995.0088
+Philipp A. Baer,3/21/2025, 5:17:09 AM,qwen2.5-coder-extra-ctx:7b,483,79,0.0562,37.6483
+Philipp A. Baer,3/20/2025, 3:40:24 PM,qwen2.5-coder-extra-ctx:7b,46,515,0.0561,37.7045
+Philipp A. Baer,3/20/2025, 3:36:09 PM,qwen2.5-coder-extra-ctx:7b,52,325,0.0377,37.7606
+Philipp A. Baer,3/20/2025, 3:35:45 PM,qwen2.5-coder-extra-ctx:7b,45,558,0.0603,37.7983
+Philipp A. Baer,3/20/2025, 1:20:27 PM,qwen2.5-coder-extra-ctx:7b,265,332,0.0597,37.8586
+Philipp A. Baer,3/20/2025, 1:19:31 PM,qwen2.5-coder-extra-ctx:7b,266,514,0.0780,37.9183
+Philipp A. Baer,3/20/2025, 4:59:21 AM,qwen2.5-coder-extra-ctx:7b,1284,760,0.2044,37.9963
+Philipp A. Baer,3/20/2025, 4:57:57 AM,qwen2.5-coder-extra-ctx:7b,614,654,0.1268,38.2007
+Philipp A. Baer,3/20/2025, 4:57:15 AM,qwen2.5-coder-extra-ctx:7b,292,288,0.0580,38.3275
+Philipp A. Baer,3/20/2025, 4:56:29 AM,qwen2.5-coder-extra-ctx:7b,56,215,0.0271,38.3855
+Philipp A. Baer,3/20/2025, 4:32:40 AM,qwen2.5-coder-extra-ctx:7b,721,262,0.0983,38.4126
+Philipp A. Baer,3/20/2025, 4:32:17 AM,qwen2.5-coder-extra-ctx:7b,489,209,0.0698,38.5109
+Philipp A. Baer,3/20/2025, 4:31:54 AM,qwen2.5-coder-extra-ctx:7b,42,421,0.0463,38.5807
+Philipp A. Baer,3/19/2025, 10:09:16 AM,qwen2.5-coder-extra-ctx:7b,501,135,0.0636,38.6270
+Philipp A. Baer,3/19/2025, 6:48:38 AM,qwen2.5-coder-extra-ctx:7b,39,542,0.0581,38.6906
+Philipp A. Baer,3/19/2025, 4:57:21 AM,qwen2.5-coder-extra-ctx:7b,493,497,0.0990,38.7487
+Philipp A. Baer,3/19/2025, 4:56:46 AM,qwen2.5-coder-extra-ctx:7b,37,440,0.0477,38.8477
+Philipp A. Baer,3/19/2025, 4:38:40 AM,qwen2.5-coder-extra-ctx:7b,45,1035,0.1080,38.8954
+Philipp A. Baer,3/19/2025, 4:33:08 AM,qwen2.5-coder-extra-ctx:7b,36,283,0.0319,39.0034
+Philipp A. Baer,3/19/2025, 4:31:33 AM,qwen2.5-coder-extra-ctx:7b,53,590,0.0643,39.0353
+open-ui,3/18/2025, 8:05:21 PM,hf.co/bartowski/DeepSeek-R1-Distill-Qwen-7B-GGUF:Q4_K_M,43,1004,0.1047,99995.0113
+open-ui,3/18/2025, 7:09:56 PM,qwen2.5-coder-extra-ctx:7b,2478,129,0.2607,99995.1160
+open-ui,3/18/2025, 7:07:22 PM,qwen2.5-coder-extra-ctx:7b,1112,515,0.1627,99995.3767
+open-ui,3/18/2025, 7:02:27 PM,qwen2.5-coder-extra-ctx:7b,1730,340,0.2070,99995.5394
+open-ui,3/18/2025, 3:31:20 PM,qwen2.5-coder-extra-ctx:7b,1450,261,0.1711,99995.7464
+open-ui,3/18/2025, 10:54:45 AM,hf.co/bartowski/DeepSeek-R1-Distill-Qwen-7B-GGUF:Q4_K_M,554,552,0.1106,99995.9175
+open-ui,3/18/2025, 10:50:59 AM,hf.co/bartowski/DeepSeek-R1-Distill-Qwen-7B-GGUF:Q4_K_M,1400,1,0.1401,99996.0281
+open-ui,3/18/2025, 9:47:18 AM,hf.co/bartowski/DeepSeek-R1-Distill-Qwen-7B-GGUF:Q4_K_M,1825,445,0.2270,99996.1682
+open-ui,3/18/2025, 9:46:31 AM,hf.co/bartowski/DeepSeek-R1-Distill-Qwen-7B-GGUF:Q4_K_M,447,625,0.1072,99996.3952
+open-ui,3/18/2025, 9:44:26 AM,hf.co/bartowski/DeepSeek-R1-Distill-Qwen-7B-GGUF:Q4_K_M,487,1770,0.2257,99996.5024
+Philipp A. Baer,3/17/2025, 3:33:05 PM,qwen2.5-coder-extra-ctx:7b,2293,651,0.2944,39.0996
+Philipp A. Baer,3/17/2025, 3:31:55 PM,qwen2.5-coder-extra-ctx:7b,1718,558,0.2276,39.3940
+Philipp A. Baer,3/17/2025, 3:31:08 PM,qwen2.5-coder-extra-ctx:7b,1669,569,0.2238,39.6216
+Philipp A. Baer,3/17/2025, 3:30:27 PM,qwen2.5-coder-extra-ctx:7b,554,553,0.1107,39.8454
+Philipp A. Baer,3/17/2025, 3:28:42 PM,qwen2.5-coder-extra-ctx:7b,46,490,0.0536,39.9561
+Philipp A. Baer,3/17/2025, 12:44:52 PM,qwen2.5-coder-extra-ctx:7b,497,296,0.0793,40.0097
+Philipp A. Baer,3/17/2025, 11:41:11 AM,qwen2.5-coder-extra-ctx:7b,1547,241,0.1788,40.0890
+Philipp A. Baer,3/17/2025, 11:39:50 AM,qwen2.5-coder-extra-ctx:7b,528,552,0.1080,40.2678
+Philipp A. Baer,3/17/2025, 11:38:24 AM,qwen2.5-coder-extra-ctx:7b,686,252,0.0938,40.3758
+Philipp A. Baer,3/17/2025, 11:37:59 AM,qwen2.5-coder-extra-ctx:7b,40,189,0.0229,40.4696
+Philipp A. Baer,3/17/2025, 11:01:50 AM,qwen2.5-coder-extra-ctx:7b,47,550,0.0597,40.4925
+Philipp A. Baer,3/17/2025, 5:31:09 AM,qwen2.5-coder-extra-ctx:7b,50,190,0.0240,40.5522
+Philipp A. Baer,3/17/2025, 4:52:09 AM,qwen2.5-coder-extra-ctx:7b,1835,499,0.2334,40.5762
+Philipp A. Baer,3/17/2025, 4:49:31 AM,qwen2.5-coder-extra-ctx:7b,945,818,0.1763,40.8096
+Philipp A. Baer,3/17/2025, 4:47:01 AM,qwen2.5-coder-extra-ctx:7b,47,444,0.0491,40.9859
+Philipp A. Baer,3/16/2025, 6:56:24 AM,qwen2.5-coder-extra-ctx:7b,524,458,0.0982,41.0350
+Philipp A. Baer,3/16/2025, 6:54:12 AM,qwen2.5-coder-extra-ctx:7b,45,460,0.0505,41.1332
+Philipp A. Baer,3/16/2025, 6:45:46 AM,qwen2.5-coder-extra-ctx:7b,948,297,0.1245,41.1837
+Philipp A. Baer,3/16/2025, 6:44:00 AM,qwen2.5-coder-extra-ctx:7b,624,308,0.0932,41.3082
+Philipp A. Baer,3/16/2025, 6:43:02 AM,qwen2.5-coder-extra-ctx:7b,488,117,0.0605,41.4014
+Philipp A. Baer,3/16/2025, 6:05:54 AM,qwen2.5-coder-extra-ctx:7b,481,89,0.0570,41.4619
+Philipp A. Baer,3/16/2025, 5:32:54 AM,qwen2.5-coder-extra-ctx:7b,584,236,0.0820,41.5189
+Philipp A. Baer,3/16/2025, 5:32:01 AM,qwen2.5-coder-extra-ctx:7b,909,135,0.1044,41.6009
+Philipp A. Baer,3/16/2025, 5:31:45 AM,qwen2.5-coder-extra-ctx:7b,623,235,0.0858,41.7053
+Philipp A. Baer,3/16/2025, 5:31:17 AM,qwen2.5-coder-extra-ctx:7b,517,104,0.0621,41.7911
+Philipp A. Baer,3/16/2025, 5:11:42 AM,qwen2.5-coder-extra-ctx:7b,1365,642,0.2007,41.8532
+Philipp A. Baer,3/15/2025, 8:20:22 PM,qwen2.5-coder-extra-ctx:7b,1350,588,0.1938,42.0539
+Philipp A. Baer,3/15/2025, 8:19:47 PM,qwen2.5-coder-extra-ctx:7b,773,559,0.1332,42.2477
+Philipp A. Baer,3/15/2025, 8:19:08 PM,qwen2.5-coder-extra-ctx:7b,42,713,0.0755,42.3809
+Philipp A. Baer,3/15/2025, 9:12:09 AM,qwen2.5-coder-extra-ctx:7b,41,343,0.0384,42.4564
+Philipp A. Baer,3/15/2025, 9:11:23 AM,qwen2.5-coder-extra-ctx:7b,693,104,0.0797,42.4948
+Philipp A. Baer,3/15/2025, 9:10:56 AM,qwen2.5-coder-extra-ctx:7b,42,177,0.0219,42.5745
+Philipp A. Baer,3/15/2025, 5:02:03 AM,qwen2.5-coder-extra-ctx:7b,2310,599,0.2909,42.5964
+Philipp A. Baer,3/15/2025, 5:01:27 AM,qwen2.5-coder-extra-ctx:7b,1282,536,0.1818,42.8873
+Philipp A. Baer,3/15/2025, 4:59:14 AM,qwen2.5-coder-extra-ctx:7b,1367,339,0.1706,43.0691
+Philipp A. Baer,3/15/2025, 4:59:03 AM,qwen2.5-coder-extra-ctx:7b,1057,292,0.1349,43.2397
+Philipp A. Baer,3/15/2025, 4:58:29 AM,qwen2.5-coder-extra-ctx:7b,757,280,0.1037,43.3746
+Philipp A. Baer,3/15/2025, 4:58:05 AM,qwen2.5-coder-extra-ctx:7b,45,251,0.0296,43.4783
+Philipp A. Baer,3/14/2025, 9:23:41 PM,qwen2.5-coder-extra-ctx:7b,1892,457,0.2349,43.5079
+Philipp A. Baer,3/14/2025, 9:23:15 PM,qwen2.5-coder-extra-ctx:7b,1269,605,0.1874,43.7428
+Philipp A. Baer,3/14/2025, 9:22:59 PM,qwen2.5-coder-extra-ctx:7b,725,528,0.1253,43.9302
+Philipp A. Baer,3/14/2025, 9:21:56 PM,qwen2.5-coder-extra-ctx:7b,4497,386,0.4883,44.0555
+Philipp A. Baer,3/14/2025, 9:21:21 PM,qwen2.5-coder-extra-ctx:7b,3490,538,0.4028,44.5438
+Philipp A. Baer,3/14/2025, 5:08:57 PM,qwen2.5-coder-extra-ctx:7b,42,667,0.0709,44.9466
+Philipp A. Baer,3/14/2025, 2:29:18 PM,qwen2.5-coder-extra-ctx:7b,807,233,0.1040,45.0175
+Philipp A. Baer,3/14/2025, 2:28:55 PM,qwen2.5-coder-extra-ctx:7b,501,287,0.0788,45.1215
+Philipp A. Baer,3/14/2025, 2:27:01 PM,qwen2.5-coder-extra-ctx:7b,292,189,0.0481,45.2003
+Philipp A. Baer,3/14/2025, 2:26:44 PM,qwen2.5-coder-extra-ctx:7b,43,231,0.0274,45.2484
+Philipp A. Baer,3/14/2025, 1:37:17 PM,qwen2.5-coder-extra-ctx:7b,575,604,0.1179,45.2758
+Philipp A. Baer,3/14/2025, 1:36:56 PM,qwen2.5-coder-extra-ctx:7b,46,512,0.0558,45.3937
+Philipp A. Baer,3/14/2025, 1:35:15 PM,qwen2.5-coder-extra-ctx:7b,2633,839,0.3472,45.4495
+Philipp A. Baer,3/14/2025, 1:33:35 PM,qwen2.5-coder-extra-ctx:7b,1715,899,0.2614,45.7967
+Philipp A. Baer,3/14/2025, 1:32:42 PM,qwen2.5-coder-extra-ctx:7b,1573,700,0.2273,46.0581
+Philipp A. Baer,3/14/2025, 1:29:46 PM,qwen2.5-coder-extra-ctx:7b,769,203,0.0972,46.2854
+Philipp A. Baer,3/14/2025, 1:28:11 PM,qwen2.5-coder-extra-ctx:7b,52,700,0.0752,46.3826
+Philipp A. Baer,3/14/2025, 1:27:36 PM,qwen2.5-coder-extra-ctx:7b,4644,877,0.5521,46.4578
+Philipp A. Baer,3/14/2025, 1:25:39 PM,qwen2.5-coder-extra-ctx:7b,4423,455,0.4878,47.0099
+Philipp A. Baer,3/14/2025, 1:25:09 PM,qwen2.5-coder-extra-ctx:7b,2980,721,0.3701,47.4977
+Philipp A. Baer,3/14/2025, 1:00:56 PM,qwen2.5-coder-extra-ctx:7b,2626,221,0.2847,47.8678
+Philipp A. Baer,3/14/2025, 12:59:20 PM,qwen2.5-coder-extra-ctx:7b,1511,645,0.2156,48.1525
+Philipp A. Baer,3/14/2025, 12:58:48 PM,qwen2.5-coder-extra-ctx:7b,1426,547,0.1973,48.3681
+Philipp A. Baer,3/14/2025, 12:58:06 PM,qwen2.5-coder-extra-ctx:7b,623,284,0.0907,48.5654
+Philipp A. Baer,3/14/2025, 12:57:15 PM,qwen2.5-coder-extra-ctx:7b,814,222,0.1036,48.6561
+Philipp A. Baer,3/14/2025, 12:56:27 PM,qwen2.5-coder-extra-ctx:7b,75,285,0.0360,48.7597
+Philipp A. Baer,3/14/2025, 12:44:30 PM,qwen2.5-coder-extra-ctx:7b,431,696,0.1127,48.7957
+Philipp A. Baer,3/14/2025, 12:43:55 PM,qwen2.5-coder-extra-ctx:7b,54,362,0.0416,48.9084
+Philipp A. Baer,3/14/2025, 9:18:44 AM,qwen2.5-coder-extra-ctx:7b,2265,683,0.2948,48.9500
+Philipp A. Baer,3/14/2025, 9:17:32 AM,qwen2.5-coder-extra-ctx:7b,1635,613,0.2248,49.2448
+Philipp A. Baer,3/14/2025, 9:17:02 AM,qwen2.5-coder-extra-ctx:7b,1551,542,0.2093,49.4696
+Philipp A. Baer,3/14/2025, 9:14:40 AM,qwen2.5-coder-extra-ctx:7b,525,535,0.1060,49.6789
+Philipp A. Baer,3/14/2025, 8:29:50 AM,qwen2.5-coder-extra-ctx:7b,45,458,0.0503,49.7849
+Philipp A. Baer,3/13/2025, 8:30:22 AM,qwen2.5-coder-extra-ctx:7b,569,307,0.0876,49.8352
+Philipp A. Baer,3/13/2025, 8:28:22 AM,qwen2.5-coder-extra-ctx:7b,51,497,0.0548,49.9228
+Philipp A. Baer,3/13/2025, 8:27:24 AM,qwen2.5-coder-extra-ctx:7b,35,189,0.0224,49.9776
+open-ui,3/12/2025, 7:44:21 AM,llama3.2:latest,768,273,0.0312,99996.7281
+open-ui,3/12/2025, 7:42:17 AM,llama3.2:latest,357,396,0.0226,99996.7593
+open-ui,3/12/2025, 7:39:06 AM,hf.co/bartowski/DeepSeek-R1-Distill-Qwen-7B-GGUF:Q4_K_M,16,2037,0.2053,99996.7819
+Maged,3/5/2025, 3:43:16 PM,viewpoint-local,524,449,0.0292,49.9555
+Maged,3/5/2025, 2:05:20 PM,viewpoint-local,30,481,0.0153,49.9847
+Ion,3/4/2025, 7:59:57 AM,llama3.2:latest,518,584,0.0331,49.7581
+Ion,3/4/2025, 7:58:36 AM,llama3.2:latest,2048,479,0.0758,49.7912
+open-ui,3/4/2025, 7:54:47 AM,viewpoint-local,591,534,0.0338,99996.9872
+open-ui,3/4/2025, 7:54:00 AM,viewpoint-local,606,622,0.0368,99997.0210
+Vishnu,3/4/2025, 7:33:01 AM,viewpoint-local,2048,431,0.0744,49.9256
+open-ui,3/4/2025, 7:10:05 AM,viewpoint-local,571,479,0.0315,99997.0578
+Ion,3/3/2025, 5:49:34 PM,viewpoint-local,1207,402,0.0483,49.8670
+Ion,3/3/2025, 3:35:39 PM,llama3.2:latest,993,206,0.0360,49.9153
+Ion,3/3/2025, 3:34:41 PM,llama3.2:latest,660,320,0.0294,49.9513
+Ion,3/3/2025, 3:33:53 PM,llama3.2:latest,251,391,0.0193,49.9807
+open-ui,3/3/2025, 2:38:47 PM,viewpoint-local,10,551,2.8050,99997.0893
+open-ui,3/2/2025, 11:00:04 AM,viewpoint-local,477,572,0.0629,99999.8943
+open-ui,3/2/2025, 10:59:24 AM,viewpoint-local,14,456,0.0282,99999.9572
+Vishnu,3/2/2025, 10:57:10 AM,viewpoint-local,855,512,0.0820,999.7907
+Vishnu,3/2/2025, 10:56:33 AM,viewpoint-local,285,560,0.0507,999.8727
+Vishnu,3/2/2025, 10:56:05 AM,viewpoint-local,280,432,0.0427,999.9234
+Vishnu,3/2/2025, 10:54:48 AM,viewpoint-local,13,260,0.0164,999.9661
+open-ui,3/2/2025, 10:51:56 AM,viewpoint-local,14,229,0.0146,99999.9854
+Vishnu,2/28/2025, 9:09:44 AM,llama3.2:latest,30,261,0.0175,999.9825
+Timo,2/28/2025, 9:04:52 AM,viewpoint-local,12,116,0.0077,99999.9493
+Timo,2/28/2025, 9:00:49 AM,viewpoint-local,8,709,0.0430,99999.9570


### PR DESCRIPTION
**Title:** `fix: add Authorization header to Records page API calls`

**Description:**

## Problem

The Records page (`/records`) was making API calls to `/api/v1/panel/records` and `/api/v1/panel/records/export` without an `Authorization` header. The middleware requires a `Bearer` token for all `/api/v1/panel/*` routes, causing both calls to return `401 Unauthorized` — resulting in an empty records table and a broken export button.

## Fix

Read the `access_token` from `localStorage` (consistent with how the Panel/Usage page handles auth) and include it as `Authorization: Bearer <token>` in both:
- `fetchRecords` — so the records table loads correctly
- `handleExport` — so the CSV export button works

## Testing

- Records table now loads data correctly on the `/records` page
- Export button downloads a valid `usage_records_<date>.csv` file
- Verified against a PostgreSQL instance with 1,162+ usage records